### PR TITLE
Allow-a-source_value-to-be-an-object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ hello_milvus.py
 temp/
 *.trace
 examples/private
+launch.json
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/src/solace_ai_event_connector/common/message.py
+++ b/src/solace_ai_event_connector/common/message.py
@@ -50,6 +50,8 @@ class Message:
         # If the expression is callable, call it
         if callable(expression):
             return expression(self)
+        if isinstance(expression, (dict, list)):
+            return expression
         # If the expression starts with 'template:', render the template
         if expression.startswith("template:"):
             return self.fill_template(expression.split(":", 1)[1])
@@ -376,7 +378,7 @@ class Message:
         # All we need is the list of ack callbacks
         message.ack_callbacks.extend(self.ack_callbacks)
 
-    def trace(self, trace_queue, location, type):
+    def trace(self, trace_queue, location, trace_type):
         trace_string = ""
         if (self.payload is not None) and (len(self.payload) > 0):
             trace_string = (
@@ -407,7 +409,7 @@ class Message:
         trace_message = TraceMessage(
             location=location,
             message=trace_string,
-            type=type,
+            trace_type=trace_type,
         )
         trace_queue.put(trace_message)
 

--- a/src/solace_ai_event_connector/common/trace_message.py
+++ b/src/solace_ai_event_connector/common/trace_message.py
@@ -2,10 +2,10 @@
 
 
 class TraceMessage:
-    def __init__(self, message, location, type="Trace"):
+    def __init__(self, message, location, trace_type="Trace"):
         self.message = message
         self.location = location
-        self.type = type
+        self.trace_type = trace_type
 
     def __str__(self):
-        return f"{self.type} at {self.location}\n{self.message}\n"
+        return f"{self.trace_type} at {self.location}\n{self.message}\n"

--- a/src/solace_ai_event_connector/common/utils.py
+++ b/src/solace_ai_event_connector/common/utils.py
@@ -230,7 +230,7 @@ def create_lambda_function_for_source_expression(source_expression):
 def get_source_expression(config_obj, key="source_expression"):
     if "source_value" in config_obj:
         source_value = config_obj.get("source_value")
-        if callable(source_value):
+        if callable(source_value) or isinstance(source_value, (dict, list)):
             return source_value
         return "static:" + str(source_value)
     return config_obj.get(key, None)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,7 +1,6 @@
 """This file tests the input_transforms configuration and execution"""
 
 import sys
-import queue
 
 sys.path.append("src")
 
@@ -298,3 +297,30 @@ flows:
         create_connector(config_yaml)
     except ValueError as e:
         assert str(e).endswith("Transform does not have a dest expression")
+
+
+def test_source_value_as_an_object():
+    """Test that a source value can be an object"""
+    # Create a simple configuration
+    config_yaml = """
+flows:
+  - name: test_flow
+    components:
+      - component_name: pass_through
+        component_module: pass_through
+        input_transforms:
+          - type: copy
+            source_value:
+              one: 1
+              two: 2
+            dest_expression: user_data.temp:my_obj
+        component_input:
+          source_expression: user_data.temp
+"""
+
+    message = Message()
+    output_message = create_and_run_component(config_yaml, message)
+
+    # Check the output
+    assert output_message.get_data("user_data.temp") == {"my_obj": {"one": 1, "two": 2}}
+    assert output_message.get_data("previous") == {"my_obj": {"one": 1, "two": 2}}


### PR DESCRIPTION
Small change to allow both lists and objects to be specified directly in the source_value parameter for input_transforms
