### PR TITLE
Add_langchain_chat_model_with_history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ hello_milvus.py
 temp/
 *.trace
 examples/private
+launch.json
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -133,9 +133,15 @@ Here is an example of using the `invoke_functions` module to do some simple oper
 ##### source_expression()
 
 If the `invoke` block is used within an area of the configuration that relates to message processing 
-(e.g. input_transforms), an invoke function call can use the special function `source_expression()` for 
+(e.g. input_transforms), an invoke function call can use the special function `source_expression(<expression>[, type])` for 
 any of its parameters. This function will be replaced with the value of the source expression at runtime.
-It is an error to use `source_expression()` outside of a message processing.
+It is an error to use `source_expression()` outside of a message processing. The second parameter is optional
+and will convert the result to the specified type. The following types are supported:
+- `int`
+- `float`
+- `bool`
+- `str`
+If the value is a dict or list, the type request will be ignored
 
 Example:
 ```yaml
@@ -150,12 +156,13 @@ Example:
               function: add
               params:
                 positional:
-                  - source_expression(input.payload:my_obj.val1)
+                  - source_expression(input.payload:my_obj.val1, int)
                   - 2
          dest_expression: user_data.my_obj:result
 ```
 
-In the above example, the `source_expression()` function is used to get the value of `input.payload:my_obj.val1` and add 2 to it.
+In the above example, the `source_expression()` function is used to get the value of `input.payload:my_obj.val1`,
+convert it to an `int` and add 2 to it.
 
 ##### user_processor component and invoke
 

--- a/examples/chat_model_with_history.yaml
+++ b/examples/chat_model_with_history.yaml
@@ -1,0 +1,50 @@
+---
+# Example uses goes from STDIN to STDOUT with a chat model with history
+log:
+  stdout_log_level: INFO
+  log_file_level: DEBUG
+  log_file: solace_ai_event_connector.log
+
+# List of flows
+flows:
+  - name: test_flow
+    components:
+
+      # Input from a Solace broker
+      - component_name: stdin
+        component_module: stdin_input
+        component_config:
+
+      - component_name: chat_with_history
+        component_module: langchain_chat_model_with_history
+        component_config:
+          langchain_module: langchain_aws
+          langchain_class: ChatBedrock
+          langchain_component_config:
+            model_id: anthropic.claude-3-sonnet-20240229-v1:0
+            model_kwargs:
+              temperature: 0.01
+          history_module: langchain_core.chat_history
+          history_class: InMemoryChatMessageHistory
+          history_max_turns: 2
+          history_max_length: 6000
+        input_transforms:
+          - type: copy
+            source_value: 1
+            dest_expression: user_data.temp:session_id
+          - type: copy
+            source_value:
+                content: "You are a helpful assistant"
+                role: "system"
+            dest_expression: user_data.temp:messages.0
+          - type: copy
+            source_expression: input.payload:text
+            dest_expression: user_data.temp:messages.1.content
+          - type: copy
+            source_value: user
+            dest_expression: user_data.temp:messages.1.role
+        component_input:
+          source_expression: user_data.temp
+
+      - component_name: stdout
+        component_module: stdout_output

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,11 +30,12 @@ isort==5.13.2
 jmespath==1.0.1
 jsonpatch==1.33
 jsonpointer==2.4
-langchain==0.1.9
-langchain-community==0.0.22
-langchain-core==0.1.26
+langchain==0.1.16
+langchain-community==0.0.34
+langchain-core==0.1.46
 langchain-openai==0.0.3
-langsmith==0.1.5
+langchain-text-splitters==0.0.1
+langsmith==0.1.51
 marshmallow==3.20.2
 mccabe==0.7.0
 minio==7.2.4
@@ -43,6 +44,7 @@ mypy-extensions==1.0.0
 numpy==1.26.3
 openai==1.9.0
 opensearch-py==2.4.2
+orjson==3.10.1
 packaging==23.2
 pandas==2.2.0
 platformdirs==4.1.0
@@ -66,6 +68,8 @@ requests==2.31.0
 requests-aws4auth==1.2.3
 s3transfer==0.10.0
 six==1.16.0
+slack-bolt==1.18.1
+slack_sdk==3.27.1
 sniffio==1.3.0
 solace-pubsubplus==1.6.0
 SQLAlchemy==2.0.25

--- a/src/solace_ai_event_connector/common/message.py
+++ b/src/solace_ai_event_connector/common/message.py
@@ -46,7 +46,7 @@ class Message:
     #
     # The type of the data returned will depend on the data type specified. It could be an object,
     # array, string, etc.
-    def get_data(self, expression, calling_object=None):
+    def get_data(self, expression, calling_object=None, data_type=None):
         # If the expression is callable, call it
         if callable(expression):
             return expression(self)
@@ -59,7 +59,23 @@ class Message:
             return expression.split(":", 1)[1]
         data_object = self.get_data_object(expression, calling_object=calling_object)
         data = self.get_data_value(data_object, expression)
+
+        if data_type:
+            data = self.convert_data_type(data, data_type)
+
         return data
+
+    def convert_data_type(self, data, data_type):
+        type_map = {
+            "string": str,
+            "int": int,
+            "float": float,
+            "bool": bool,
+        }
+        if isinstance(data, (dict, list)):
+            # Can't convert a dict or list to a primitive type
+            return data
+        return type_map.get(data_type, str)(data)
 
     def set_data(self, expression, value):
         if ":" not in expression:

--- a/src/solace_ai_event_connector/flow/flow.py
+++ b/src/solace_ai_event_connector/flow/flow.py
@@ -14,6 +14,7 @@ class Flow:
         instance_name=None,
         storage_manager=None,
         trace_queue=None,
+        flow_instance_index=0,
     ):
         self.flow_config = flow_config
         self.flow_index = flow_index
@@ -25,6 +26,7 @@ class Flow:
         self.instance_name = instance_name
         self.storage_manager = storage_manager
         self.trace_queue = trace_queue
+        self.flow_instance_index = flow_instance_index
         self.threads = []
         self.create_components()
 

--- a/src/solace_ai_event_connector/flow_components/general/iterate.py
+++ b/src/solace_ai_event_connector/flow_components/general/iterate.py
@@ -34,7 +34,11 @@ class Iterate(ComponentBase):
             # Create a new message for each item unless it is the last item
             # in which case we reuse the existing message
             if item != data[-1]:
-                new_message = Message(payload=item)
+                topic = message.get_topic()
+                user_properties = message.get_user_properties()
+                new_message = Message(
+                    payload=item, topic=topic, user_properties=user_properties
+                )
             else:
                 new_message = message
 

--- a/src/solace_ai_event_connector/flow_components/general/langchain/langchain_base.py
+++ b/src/solace_ai_event_connector/flow_components/general/langchain/langchain_base.py
@@ -37,7 +37,6 @@ class LangChainBase(ComponentBase):
 
     def create_component(self, config, cls):
         component = None
-        component = cls(**config)
         if not config:
             config = {}
         try:

--- a/src/solace_ai_event_connector/flow_components/general/langchain/langchain_chat_model.py
+++ b/src/solace_ai_event_connector/flow_components/general/langchain/langchain_chat_model.py
@@ -1,131 +1,17 @@
 # This is a wrapper around all the LangChain chat models
 # The configuration will control dynamic loading of the chat models
 
-import json
-import yaml
-
-from solace_ai_event_connector.common.utils import get_obj_text
-from langchain.schema.messages import (
-    HumanMessage,
-    SystemMessage,
-    AIMessage,
-    FunctionMessage,
-    ChatMessage,
-)
-
-from solace_ai_event_connector.flow_components.general.langchain.langchain_base import (
-    LangChainBase,
+from solace_ai_event_connector.flow_components.general.langchain.langchain_chat_model_base import (
+    LangChainChatModelBase,
+    info_base,
 )
 
 
-info = {
-    "class_name": "LangChainChatModel",
-    "description": "Provide access to all the LangChain chat models via configuration",
-    "config_parameters": [
-        {
-            "name": "langchain_module",
-            "required": True,
-            "description": "The chat model module - e.g. 'langchain_openai.chat_models'",
-        },
-        {
-            "name": "langchain_class",
-            "required": True,
-            "description": "The chat model class to use - e.g. ChatOpenAI",
-        },
-        {
-            "name": "langchain_component_config",
-            "required": True,
-            "description": "Model specific configuration for the chat model. "
-            "See documentation for valid parameter names.",
-        },
-        {
-            "name": "llm_response_format",
-            "required": False,
-            "description": (
-                "The response format for this LLM request. This can be "
-                "'json', 'yaml', or 'text'. If set to 'json' or 'yaml', the response "
-                "will be parsed by the appropriate parser and the fields will be "
-                "available in the response object. If set to 'text', the response will "
-                "be returned as a string."
-            ),
-        },
-    ],
-    "input_schema": {
-        "type": "object",
-        "properties": {
-            "messages": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "role": {
-                            "type": "string",
-                            "description": "The role of the LLM message (user, assistant, system)",
-                        },
-                        "content": {
-                            "type": "string",
-                            "description": "The content of the LLM message",
-                        },
-                    },
-                    "required": ["content"],
-                },
-            },
-        },
-        "required": ["messages"],
-    },
-    "output_schema": {
-        "type": "object",
-        "properties": {"result": {"type": "string"}},
-        "required": ["result"],
-        "description": (
-            "The result of the chat model invocation. If a format "
-            "is specified, then the result text will be parsed and "
-            "the fields will be available in the response object."
-        ),
-    },
-}
+info = info_base
+info["class_name"] = "LangChainChatModel"
 
 
-class LangChainChatModel(LangChainBase):
-    # def __init__(self, **kwargs):
-    #     super().__init__(**kwargs)
+class LangChainChatModel(LangChainChatModelBase):
 
-    def invoke(self, message, data):
-        messages = []
-
-        for item in data["messages"]:
-            if item["role"] == "system":
-                messages.append(SystemMessage(content=item["content"]))
-            elif item["role"] == "user" or item["role"] == "human":
-                messages.append(HumanMessage(content=item["content"]))
-            elif item["role"] == "assistant" or item["role"] == "bot":
-                messages.append(AIMessage(content=item["content"]))
-            elif item["role"] == "function":
-                messages.append(FunctionMessage(content=item["content"]))
-            elif item["role"] == "chat":
-                messages.append(ChatMessage(content=item["content"]))
-            else:
-                raise ValueError(
-                    f"Invalid message role for Chat Model invocation: {item['role']}"
-                )
-
-        llm_res = self.component.invoke(messages)
-        print("LangChainChatModel: llm_res: " + str(llm_res))
-
-        res_format = self.get_config("llm_response_format", "text")
-        if res_format == "json":
-            obj_text = get_obj_text("json", llm_res.content)
-            try:
-                json_res = json.loads(obj_text)
-                return json_res
-            except Exception as e:
-                raise ValueError(f"Error parsing LLM JSON response: {str(e)}") from e
-        elif res_format == "yaml":
-            obj_text = get_obj_text("yaml", llm_res.content)
-            try:
-                yaml_res = yaml.safe_load(obj_text)
-                return yaml_res
-            except Exception as e:
-                raise ValueError(f"Error parsing LLM YAML response: {str(e)}") from e
-        else:
-            return llm_res.content
+    def invoke_model(self, messages, session_id=None, clear_history=False):
+        return self.component.invoke(messages)

--- a/src/solace_ai_event_connector/flow_components/general/langchain/langchain_chat_model_base.py
+++ b/src/solace_ai_event_connector/flow_components/general/langchain/langchain_chat_model_base.py
@@ -1,0 +1,138 @@
+# This is the base class of a wrapper around all the LangChain chat models
+# The configuration will control dynamic loading of the chat models
+
+import json
+import yaml
+from abc import abstractmethod
+
+from solace_ai_event_connector.common.utils import get_obj_text
+from langchain.schema.messages import (
+    HumanMessage,
+    SystemMessage,
+    AIMessage,
+    FunctionMessage,
+    ChatMessage,
+)
+
+from solace_ai_event_connector.flow_components.general.langchain.langchain_base import (
+    LangChainBase,
+)
+
+
+info_base = {
+    "class_name": "<override>",
+    "description": "Provide access to all the LangChain chat models via configuration",
+    "config_parameters": [
+        {
+            "name": "langchain_module",
+            "required": True,
+            "description": "The chat model module - e.g. 'langchain_openai.chat_models'",
+        },
+        {
+            "name": "langchain_class",
+            "required": True,
+            "description": "The chat model class to use - e.g. ChatOpenAI",
+        },
+        {
+            "name": "langchain_component_config",
+            "required": True,
+            "description": "Model specific configuration for the chat model. "
+            "See documentation for valid parameter names.",
+        },
+        {
+            "name": "llm_response_format",
+            "required": False,
+            "description": (
+                "The response format for this LLM request. This can be "
+                "'json', 'yaml', or 'text'. If set to 'json' or 'yaml', the response "
+                "will be parsed by the appropriate parser and the fields will be "
+                "available in the response object. If set to 'text', the response will "
+                "be returned as a string."
+            ),
+        },
+    ],
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "messages": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "role": {
+                            "type": "string",
+                            "description": "The role of the LLM message (user, assistant, system)",
+                        },
+                        "content": {
+                            "type": "string",
+                            "description": "The content of the LLM message",
+                        },
+                    },
+                    "required": ["content"],
+                },
+            },
+        },
+        "required": ["messages"],
+    },
+    "output_schema": {
+        "type": "object",
+        "properties": {"result": {"type": "string"}},
+        "required": ["result"],
+        "description": (
+            "The result of the chat model invocation. If a format "
+            "is specified, then the result text will be parsed and "
+            "the fields will be available in the response object."
+        ),
+    },
+}
+
+
+class LangChainChatModelBase(LangChainBase):
+
+    def invoke(self, message, data):
+        messages = []
+
+        for item in data["messages"]:
+            if item["role"] == "system":
+                messages.append(SystemMessage(content=item["content"]))
+            elif item["role"] == "user" or item["role"] == "human":
+                messages.append(HumanMessage(content=item["content"]))
+            elif item["role"] == "assistant" or item["role"] == "bot":
+                messages.append(AIMessage(content=item["content"]))
+            elif item["role"] == "function":
+                messages.append(FunctionMessage(content=item["content"]))
+            elif item["role"] == "chat":
+                messages.append(ChatMessage(content=item["content"]))
+            else:
+                raise ValueError(
+                    f"Invalid message role for Chat Model invocation: {item['role']}"
+                )
+
+        session_id = data.get("session_id", None)
+        clear_history = data.get("clear_history", False)
+
+        llm_res = self.invoke_model(
+            messages, session_id=session_id, clear_history=clear_history
+        )
+
+        res_format = self.get_config("llm_response_format", "text")
+        if res_format == "json":
+            obj_text = get_obj_text("json", llm_res.content)
+            try:
+                json_res = json.loads(obj_text)
+                return json_res
+            except Exception as e:
+                raise ValueError(f"Error parsing LLM JSON response: {str(e)}") from e
+        elif res_format == "yaml":
+            obj_text = get_obj_text("yaml", llm_res.content)
+            try:
+                yaml_res = yaml.safe_load(obj_text)
+                return yaml_res
+            except Exception as e:
+                raise ValueError(f"Error parsing LLM YAML response: {str(e)}") from e
+        else:
+            return llm_res.content
+
+    @abstractmethod
+    def invoke_model(self, messages, session_id=None, clear_history=False):
+        pass

--- a/src/solace_ai_event_connector/flow_components/general/langchain/langchain_chat_model_with_history.py
+++ b/src/solace_ai_event_connector/flow_components/general/langchain/langchain_chat_model_with_history.py
@@ -1,0 +1,160 @@
+"""A chat model based on LangChain that includes keeping per-session history of the conversation."""
+
+import threading
+
+from langchain_core.chat_history import BaseChatMessageHistory
+from langchain_core.runnables.history import RunnableWithMessageHistory
+from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+
+# from langchain.memory import ConversationTokenBufferMemory
+from langchain.schema.messages import (
+    HumanMessage,
+    SystemMessage,
+)
+
+from solace_ai_event_connector.flow_components.general.langchain.langchain_chat_model_base import (
+    LangChainChatModelBase,
+    info_base,
+)
+
+
+info = info_base
+info["class_name"] = "LangChainChatModelWithHistory"
+info["description"] = (
+    "A chat model based on LangChain that includes keeping per-session history of "
+    "the conversation. Note that this component will only take the first system "
+    "message and the first human message in the messages array."
+)
+info["config_parameters"].extend(
+    [
+        {
+            "name": "history_max_turns",
+            "required": False,
+            "description": "The maximum number of turns to keep in the history. "
+            "If not set, the history will be limited to 20 turns.",
+            "default": 20,
+        },
+        {
+            "name": "history_max_tokens",
+            "required": False,
+            "description": "The maximum number of tokens to keep in the history. "
+            "If not set, the history will be limited to 8000 tokens.",
+            "default": 8000,
+        },
+        {
+            "name": "history_module",
+            "required": False,
+            "description": "The module that contains the history class. "
+            "Default: 'langchain_community.chat_message_histories'",
+            "default": "langchain_community.chat_message_histories",
+        },
+        {
+            "name": "history_class",
+            "required": False,
+            "description": "The class to use for the history. Default: 'ChatMessageHistory'",
+            "default": "ChatMessageHistory",
+        },
+        {
+            "name": "history_config",
+            "required": False,
+            "description": "The configuration for the history class.",
+            "type": "object",
+        },
+    ]
+)
+info["input_schema"]["properties"]["session_id"] = {
+    "type": "string",
+    "description": "The session ID for the conversation.",
+}
+info["input_schema"]["required"].append("session_id")
+info["input_schema"]["properties"]["clear_history"] = {
+    "type": "boolean",
+    "description": "Whether to clear the history for the session.",
+    "default": False,
+}
+
+
+class LangChainChatModelWithHistory(LangChainChatModelBase):
+    _histories: dict = {}
+    _lock = threading.Lock()
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.history_max_turns = self.get_config("history_max_turns", 20)
+        self.history_max_tokens = self.get_config("history_max_tokens", 8000)
+
+    def invoke_model(self, messages, session_id=None, clear_history=False):
+
+        if clear_history:
+            self.clear_history(session_id)
+
+        # Find the first SystemMessage and HumanMessage
+        system_prompt = "You are a helpful assistant."
+        for message in messages:
+            if isinstance(message, SystemMessage):
+                system_prompt = message.content
+                break
+
+        human_message = ""
+        for message in messages:
+            if isinstance(message, HumanMessage):
+                human_message = message.content
+                break
+
+        # Create the prompt template
+        template = ChatPromptTemplate.from_messages(
+            [
+                SystemMessage(system_prompt),
+                MessagesPlaceholder(variable_name="chat_history"),
+                ("human", "{input}"),
+            ]
+        )
+
+        runnable = RunnableWithMessageHistory(
+            template | self.component,
+            self.get_history,
+            input_messages_key="input",
+            history_messages_key="chat_history",
+        )
+
+        return runnable.invoke(
+            {"input": human_message},
+            config={
+                "configurable": {"session_id": session_id},
+            },
+        )
+
+    def create_history(self):
+
+        history_class = self.load_component(
+            self.get_config(
+                "history_module", "langchain_community.chat_message_histories"
+            ),
+            self.get_config("history_class", "ChatMessageHistory"),
+        )
+        config = self.get_config("history_config", {})
+        history = self.create_component(config, history_class)
+        # memory = ConversationTokenBufferMemory(
+        #     chat_memory=history, llm=self.component, max_token_limit=history_max_tokens
+        # )
+        return history
+
+    def get_history(self, session_id: str) -> BaseChatMessageHistory:
+        with self._lock:
+            # TBD - we could do some history pruning here if we can't beat langchain into submission
+            #       for now just implement the turns limit - later can look at tokens
+            if session_id not in self._histories:
+                self._histories[session_id] = self.create_history()
+            # Get all the messages from the history
+            messages = self._histories[session_id].messages
+            if len(messages) > self.history_max_turns:
+                # Set the history to the last max_turns messages
+                self._histories[session_id].messages = messages[
+                    -self.history_max_turns :
+                ]
+            return self._histories[session_id]
+
+    def clear_history(self, session_id: str):
+        with self._lock:
+            if session_id in self._histories:
+                del self._histories[session_id]

--- a/src/solace_ai_event_connector/flow_components/inputs_outputs/slack_base.py
+++ b/src/solace_ai_event_connector/flow_components/inputs_outputs/slack_base.py
@@ -1,0 +1,36 @@
+"""Base class for all Slack components"""
+
+from abc import ABC, abstractmethod
+from slack_bolt import App  # pylint: disable=import-error
+from solace_ai_event_connector.flow_components.component_base import ComponentBase
+
+
+class SlackBase(ComponentBase, ABC):
+    _slack_apps = {}
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.slack_bot_token = self.get_config("slack_bot_token")
+        self.slack_app_token = self.get_config("slack_app_token")
+        self.max_file_size = self.get_config("max_file_size", 20)
+        self.max_total_file_size = self.get_config("max_total_file_size", 20)
+        self.share_slack_connection = self.get_config("share_slack_connection")
+
+        if self.share_slack_connection:
+            if self.slack_bot_token not in SlackBase._slack_apps:
+                self.app = App(token=self.slack_bot_token)
+                SlackBase._slack_apps[self.slack_bot_token] = self.app
+            else:
+                self.app = SlackBase._slack_apps[self.slack_bot_token]
+        else:
+            self.app = App(token=self.slack_bot_token)
+
+    @abstractmethod
+    def invoke(self, message, data):
+        pass
+
+    def __str__(self):
+        return self.__class__.__name__ + " " + str(self.config)
+
+    def __repr__(self):
+        return self.__str__()

--- a/src/solace_ai_event_connector/flow_components/inputs_outputs/slack_output.py
+++ b/src/solace_ai_event_connector/flow_components/inputs_outputs/slack_output.py
@@ -1,0 +1,149 @@
+import base64
+from copy import deepcopy
+
+
+from solace_ai_event_connector.flow_components.inputs_outputs.slack_base import (
+    SlackBase,
+)
+from solace_ai_event_connector.common.message import Message
+from solace_ai_event_connector.common.log import log
+
+
+info = {
+    "class_name": "SlackOutput",
+    "description": (
+        "Slack output component. The component sends messages to Slack channels using the Bolt API."
+    ),
+    "config_parameters": [
+        {
+            "name": "slack_bot_token",
+            "type": "string",
+            "description": "The Slack bot token to connect to Slack.",
+        },
+        {
+            "name": "slack_app_token",
+            "type": "string",
+            "description": "The Slack app token to connect to Slack.",
+        },
+        {
+            "name": "share_slack_connection",
+            "type": "string",
+            "description": "Share the Slack connection with other components in this instance.",
+        },
+    ],
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "message_info": {
+                "type": "object",
+                "properties": {
+                    "channel": {
+                        "type": "string",
+                    },
+                    "type": {
+                        "type": "string",
+                    },
+                    "user_email": {
+                        "type": "string",
+                    },
+                    "client_msg_id": {
+                        "type": "string",
+                    },
+                    "ts": {
+                        "type": "string",
+                    },
+                    "subtype": {
+                        "type": "string",
+                    },
+                    "event_ts": {
+                        "type": "string",
+                    },
+                    "channel_type": {
+                        "type": "string",
+                    },
+                    "user_id": {
+                        "type": "string",
+                    },
+                    "session_id": {
+                        "type": "string",
+                    },
+                },
+                "required": ["channel", "session_id"],
+            },
+            "content": {
+                "type": "object",
+                "properties": {
+                    "text": {
+                        "type": "string",
+                    },
+                    "files": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                },
+                                "content": {
+                                    "type": "string",
+                                },
+                                "mime_type": {
+                                    "type": "string",
+                                },
+                                "filetype": {
+                                    "type": "string",
+                                },
+                                "size": {
+                                    "type": "number",
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        "required": ["message_info", "content"],
+    },
+}
+
+
+class SlackOutput(SlackBase):
+    # def __init__(self, **kwargs):
+    #     super().__init__(**kwargs)
+
+    def invoke(self, message, data):
+        message_info = data.get("message_info")
+        content = data.get("content")
+        text = content.get("text")
+        channel = message_info.get("channel")
+        thread_ts = message_info.get("ts")
+        return {
+            "channel": channel,
+            "text": text,
+            "files": content.get("files"),
+            "thread_ts": thread_ts,
+        }
+
+    def send_message(self, message):
+        channel = message.get_data("previous:channel")
+        messages = message.get_data("previous:text")
+        files = message.get_data("previous:files") or []
+        thread_ts = message.get_data("previous:ts")
+
+        if not isinstance(messages, list):
+            messages = [messages]
+        for text in messages:
+            self.app.client.chat_postMessage(
+                channel=channel, text=text, thread_ts=thread_ts
+            )
+
+        for file in files:
+            file_content = base64.b64decode(file["content"])
+            self.app.client.files_upload_v2(
+                channels=channel,
+                file=file_content,
+                thread_ts=thread_ts,
+                filename=file["name"],
+            )
+
+        super().send_message(message)

--- a/src/solace_ai_event_connector/flow_components/inputs_outputs/stdout_output.py
+++ b/src/solace_ai_event_connector/flow_components/inputs_outputs/stdout_output.py
@@ -20,8 +20,6 @@ info = {
 
 
 class Stdout(ComponentBase):
-    def send_message(self, message):
-        pass
 
     def invoke(self, message, data):
         # Print the message to STDOUT

--- a/src/solace_ai_event_connector/flow_components/inputs_outputs/timer_input.py
+++ b/src/solace_ai_event_connector/flow_components/inputs_outputs/timer_input.py
@@ -25,6 +25,8 @@ info = {
             "then the component will always wait at least the interval time before "
             "generating the next message. Note that due to some messages in the pipeline, there "
             "will always be a couple of quick messages generated.",
+            "default": False,
+            "required": False,
         },
     ],
     "output_schema": "any",

--- a/src/solace_ai_event_connector/solace_ai_event_connector.py
+++ b/src/solace_ai_event_connector/solace_ai_event_connector.py
@@ -44,14 +44,20 @@ class SolaceAiEventConnector:
         """Loop through the flows and create them"""
         for index, flow in enumerate(self.config.get("flows", [])):
             log.debug("Creating flow %s", flow.get("name"))
-            flow_instance = self.create_flow(flow, index)
-            self.flows.append(flow_instance)
+            num_instances = flow.get("num_instances", 1)
+            if num_instances < 1:
+                num_instances = 1
+            for i in range(num_instances):
+                flow_instance = self.create_flow(flow, index, i)
+                self.flows.append(flow_instance)
 
-    def create_flow(self, flow: dict, index: int):
+    def create_flow(self, flow: dict, index: int, flow_instance_index: int):
         """Create a single flow"""
+
         return Flow(
             flow_config=flow,
             flow_index=index,
+            flow_instance_index=flow_instance_index,
             stop_signal=self.stop_signal,
             error_queue=self.error_queue,
             instance_name=self.instance_name,

--- a/tests/test_invoke.py
+++ b/tests/test_invoke.py
@@ -581,6 +581,98 @@ def test_invoke_with_source_expression_simple():
     assert config == {"source_expression": 3}
 
 
+def test_invoke_with_source_expression_cast_to_int():
+    """Verify that the source expression is evaluated"""
+    config = resolve_config_values(
+        {
+            "source_expression": {
+                "invoke": {
+                    "module": "invoke_functions",
+                    "function": "add",
+                    "params": {
+                        "positional": [
+                            "source_expression(input.payload:my_obj.val1, int )",
+                            2,
+                        ],
+                    },
+                },
+            },
+        }
+    )
+    message = Message(payload={"my_obj": {"val1": "1"}})
+    config["source_expression"] = config["source_expression"](message)
+    assert config == {"source_expression": 3}
+
+
+def test_invoke_with_source_expression_cast_to_float():
+    """Verify that the source expression is evaluated"""
+    config = resolve_config_values(
+        {
+            "source_expression": {
+                "invoke": {
+                    "module": "invoke_functions",
+                    "function": "add",
+                    "params": {
+                        "positional": [
+                            "source_expression(input.payload:my_obj.val1, float )",
+                            2,
+                        ],
+                    },
+                },
+            },
+        }
+    )
+    message = Message(payload={"my_obj": {"val1": "1.1"}})
+    config["source_expression"] = config["source_expression"](message)
+    assert config == {"source_expression": 3.1}
+
+
+def test_invoke_with_source_expression_cast_to_bool():
+    """Verify that the source expression is evaluated"""
+    config = resolve_config_values(
+        {
+            "source_expression": {
+                "invoke": {
+                    "module": "invoke_functions",
+                    "function": "and_op",
+                    "params": {
+                        "positional": [
+                            "source_expression(input.payload:my_obj.val1 , bool )",
+                            True,
+                        ],
+                    },
+                },
+            },
+        }
+    )
+    message = Message(payload={"my_obj": {"val1": "True"}})
+    config["source_expression"] = config["source_expression"](message)
+    assert config == {"source_expression": True}
+
+
+def test_invoke_with_source_expression_cast_to_str():
+    """Verify that the source expression is evaluated"""
+    config = resolve_config_values(
+        {
+            "source_expression": {
+                "invoke": {
+                    "module": "invoke_functions",
+                    "function": "add",
+                    "params": {
+                        "positional": [
+                            "source_expression(input.payload:my_obj.val1,str)",
+                            "2",
+                        ],
+                    },
+                },
+            },
+        }
+    )
+    message = Message(payload={"my_obj": {"val1": 1}})
+    config["source_expression"] = config["source_expression"](message)
+    assert config == {"source_expression": "12"}
+
+
 def test_invoke_with_source_expression_keyword():
     """Verify that the source expression is evaluated"""
     config = resolve_config_values(


### PR DESCRIPTION
* added integration with Slack
* support multiple instances of a flow
* add type conversion for 'source_expression()' calls in invoke
* copy message user_properties when spliting it with the iterate component
* add support for keeping history with a chat model
* add configuration on broker_output to decrement a TTL and automatically copy the user_properties for an input message into the output message