### PR TITLE
Ed/DATAGO-100959/add-dynamic-subs-to-dev-broker

### DIFF
--- a/src/solace_ai_connector/common/messaging/dev_broker_messaging.py
+++ b/src/solace_ai_connector/common/messaging/dev_broker_messaging.py
@@ -118,6 +118,22 @@ class DevBroker(Messaging):
     def ack_message(self, message):
         pass
 
+    def add_topic_subscription(self, topic_str: str, persistent_receiver=None):
+        """Adds a topic subscription to the default queue (matches SolaceMessaging interface)"""
+        queue_name = self.broker_properties.get("queue_name")
+        if not queue_name:
+            log.error("DevBroker: No default queue configured for subscription")
+            return False
+        return self.add_topic_to_queue(topic_str, queue_name)
+
+    def remove_topic_subscription(self, topic_str: str, persistent_receiver=None):
+        """Removes a topic subscription from the default queue (matches SolaceMessaging interface)"""
+        queue_name = self.broker_properties.get("queue_name")
+        if not queue_name:
+            log.error("DevBroker: No default queue configured for subscription")
+            return False
+        return self.remove_topic_from_queue(topic_str, queue_name)
+
     def add_topic_to_queue(self, topic_str: str, queue_name: str) -> bool:
         """Adds a topic subscription (regex pattern) to the specified queue's list of subscriptions."""
         if not self.connected:

--- a/src/solace_ai_connector/common/messaging/dev_broker_messaging.py
+++ b/src/solace_ai_connector/common/messaging/dev_broker_messaging.py
@@ -1,4 +1,4 @@
-"""This is a simple broker for testing purposes. It allows sending and receiving 
+"""This is a simple broker for testing purposes. It allows sending and receiving
 messages to/from queues. It supports subscriptions based on topics."""
 
 from typing import Dict, List, Any
@@ -48,6 +48,9 @@ class DevBroker(Messaging):
             if self.queues is None:
                 self.queues: Dict[str, queue.Queue] = {}
                 self.flow_kv_store.set("dev_broker:queues", self.queues)
+
+        # Need this to be able to use the same interface as the other brokers
+        self.persistent_receiver = {}
 
     def connect(self):
         self.connected = True
@@ -170,7 +173,10 @@ class DevBroker(Messaging):
 
         regex_pattern = self._subscription_to_regex(topic_str)
         with self.subscriptions_lock:
-            if regex_pattern in self.subscriptions and queue_name in self.subscriptions[regex_pattern]:
+            if (
+                regex_pattern in self.subscriptions
+                and queue_name in self.subscriptions[regex_pattern]
+            ):
                 self.subscriptions[regex_pattern].remove(queue_name)
                 if not self.subscriptions[regex_pattern]:  # If list becomes empty
                     del self.subscriptions[regex_pattern]


### PR DESCRIPTION
🧩 Complexity Level: 🟢 Low

⏱️ Estimated Review Time: 5–10 minutes

### What is the purpose of this change?

Recently, the Solace Broker received a couple of new methods to manage dynamic subscriptions. Dev Broker didn't get the same additions. This fixes that.

### How is this accomplished?

Add add_topic_subscription and remove_topic_subscription from the Dev Broker

### Anything reviews should focus on/be aware of?

Simple change. Needs to be backwards compatible