### PR TITLE
DATAGO-103079 : Restore trace stacks (#128)

### DIFF
--- a/examples/llm/litellm_chat.yaml
+++ b/examples/llm/litellm_chat.yaml
@@ -37,6 +37,7 @@ log:
   log_file_level: DEBUG
   log_file: ${LOG_FILE}
   log_format: jsonl
+  enable_trace: False
   logback: 
     rollingpolicy:
       file-name-pattern: "${LOG_FILE}.%d{yyyy-MM-dd}.%i.gz"

--- a/src/solace_ai_connector/common/messaging/solace_messaging.py
+++ b/src/solace_ai_connector/common/messaging/solace_messaging.py
@@ -107,9 +107,10 @@ class ServiceEventHandler(
 
         try:
             self.strategy = ConnectionStrategy(strategy)
-        except ValueError:
+        except ValueError as e:
             log.error(
-                f"{self.error_prefix} Invalid reconnection strategy: {strategy}. Using default strategy."
+                f"{self.error_prefix} Invalid reconnection strategy: {strategy}. Using default strategy.",
+                trace=e,
             )
             self.strategy = ConnectionStrategy.FOREVER_RETRY
 
@@ -418,8 +419,11 @@ class SolaceMessaging(Messaging):
                         **self.persistent_receiver._end_point_props,
                         **end_point_props,
                     }
-                except Exception:
-                    log.error(f"{self.error_prefix} Error setting max redelivery count")
+                except Exception as e:
+                    log.error(
+                        f"{self.error_prefix} Error setting max redelivery count",
+                        trace=e,
+                    )
 
             self.persistent_receiver.start()
 
@@ -455,8 +459,8 @@ class SolaceMessaging(Messaging):
             change_connection_status(
                 self.connection_properties, ConnectionStatus.DISCONNECTED
             )
-        except Exception:  # pylint: disable=broad-except
-            log.debug(f"{self.error_prefix} Error disconnecting")
+        except Exception as e:  # pylint: disable=broad-except
+            log.error(f"{self.error_prefix} Error disconnecting", trace=e)
 
     def get_connection_status(self):
         return self.connection_properties["status"]
@@ -530,13 +534,15 @@ class SolaceMessaging(Messaging):
             return True
         except PubSubPlusClientError as e:
             log.error(
-                f"{self.error_prefix} Error adding subscription '{topic_str}': {e}"
+                f"{self.error_prefix} Error adding subscription '{topic_str}'.",
+                trace=e,
             )
             return False
         except Exception as e:
             log.error(
-                f"{self.error_prefix} Unexpected error adding subscription '{topic_str}': {e}",
+                f"{self.error_prefix} Unexpected error adding subscription '{topic_str}'.",
                 exc_info=True,
+                trace=e,
             )
             return False
 
@@ -563,13 +569,15 @@ class SolaceMessaging(Messaging):
             return True
         except PubSubPlusClientError as e:
             log.error(
-                f"{self.error_prefix} Error removing subscription '{topic_str}': {e}"
+                f"{self.error_prefix} Error removing subscription '{topic_str}'.",
+                trace=e,
             )
             return False
         except Exception as e:
             log.error(
-                f"{self.error_prefix} Unexpected error removing subscription '{topic_str}': {e}",
+                f"{self.error_prefix} Unexpected error removing subscription '{topic_str}'.",
                 exc_info=True,
+                trace=e,
             )
             return False
 

--- a/src/solace_ai_connector/components/component_base.py
+++ b/src/solace_ai_connector/components/component_base.py
@@ -394,11 +394,12 @@ class ComponentBase:
                     self.name,
                     self.log_identifier,
                 )
-            except Exception:
+            except Exception as e:
                 log.error(
                     "[%s] %s Failed to initialize component-level RRC",
                     self.name,
                     self.log_identifier,
+                    trace=e,
                 )
                 # Decide if this should be fatal
                 raise ValueError("Failed to initialize component-level RRC") from None
@@ -566,16 +567,21 @@ class ComponentBase:
                         self.log_identifier,
                     )
                     return None
-                except TimeoutError:  # Catch timeout specifically
-                    log.error("[%s] %s RRC timed out", self.name, self.log_identifier)
-                    raise e  # Re-raise timeout
-                except Exception:
+                except TimeoutError as e:  # Catch timeout specifically
+                    log.error(
+                        "[%s] %s RRC timed out", self.name, self.log_identifier, trace=e
+                    )
+                    raise ValueError("RRC timed out") from None  # Re-raise timeout
+                except Exception as e:
                     log.error(
                         "[%s] %s Error during RRC call",
                         self.name,
                         self.log_identifier,
+                        trace=e,
                     )
-                    raise e  # Re-raise other exceptions
+                    raise ValueError(
+                        "Error during RRC call"
+                    ) from None  # Re-raise other exceptions
         else:
             # No controller found
             raise ValueError(

--- a/src/solace_ai_connector/components/general/db/mongo/mongo_handler.py
+++ b/src/solace_ai_connector/components/general/db/mongo/mongo_handler.py
@@ -43,8 +43,8 @@ class MongoHandler:
                 self.local.client = MongoClient(connection_string)
                 self.local.db = self.local.client[self.database_name]
                 log.info("Successfully connected to MongoDB database")
-            except Exception:
-                log.error("Error connecting to MongoDB database")
+            except Exception as e:
+                log.error("Error connecting to MongoDB database", trace=e)
                 raise ValueError("Failed to connect to MongoDB database") from None
         return self.local.db
 
@@ -125,8 +125,8 @@ class MongoHandler:
             result = list(cursor)
             result = self._remove_object_ids(result)
             return result
-        except Exception:
-            log.error("Error executing MongoDB query")
+        except Exception as e:
+            log.error("Error executing MongoDB query", trace=e)
             raise ValueError("Failed to execute MongoDB query") from None
 
     def get_collections(self) -> List[str]:

--- a/src/solace_ai_connector/components/general/db/mongo/mongo_insert.py
+++ b/src/solace_ai_connector/components/general/db/mongo/mongo_insert.py
@@ -115,20 +115,25 @@ class MongoDBInsertComponent(MongoDBBaseComponent):
                     try:
                         # Clean the datetime string by removing redundant timezone indicators
                         cleaned_value = value.strip()
-                        
+
                         # Handle common problematic patterns:
                         # 1. "Z UTC" - Z already indicates UTC, so remove " UTC"
                         if cleaned_value.endswith(" UTC") and "Z" in cleaned_value:
                             cleaned_value = cleaned_value[:-4].strip()
-                        
+
                         # 2. Multiple spaces or other whitespace issues
-                        elif " UTC" in cleaned_value and cleaned_value.count(" UTC") > 1:
+                        elif (
+                            " UTC" in cleaned_value and cleaned_value.count(" UTC") > 1
+                        ):
                             # Remove duplicate UTC indicators
                             cleaned_value = cleaned_value.replace(" UTC UTC", " UTC")
                         parsed_date = dateutil.parser.parse(cleaned_value)
                         return parsed_date
                     except Exception as cleanup_error:
-                        log.error(f"[mongo_insert] Failed to parse even after cleanup. Original: '{value}', Cleaned: '{cleaned_value}', Cleanup Error: {cleanup_error}")
+                        log.error(
+                            "[mongo_insert] Failed to parse even after cleanup.",
+                            trace=f"Original: '{value}', Cleaned: '{cleaned_value}', Cleanup Error: {cleanup_error}",
+                        )
                         # Provide helpful error message with suggestions
                         error_msg = (
                             f"Unable to parse datetime string: '{value}'. "

--- a/src/solace_ai_connector/components/general/llm/langchain/langchain_split_text.py
+++ b/src/solace_ai_connector/components/general/llm/langchain/langchain_split_text.py
@@ -79,8 +79,8 @@ class LangChainTextSplitter(LangChainBase):
         try:
             chunks = self.component.split_text(data)
             return chunks
-        except Exception:
-            log.error("Error splitting text")
+        except Exception as e:
+            log.error("Error splitting text", trace=e)
             return []
 
 
@@ -105,6 +105,6 @@ class SingleChunkSplitter:
         """
         try:
             return [data]
-        except Exception:
-            log.error("Error wrapping data")
+        except Exception as e:
+            log.error("Error wrapping data", trace=e)
             return []

--- a/src/solace_ai_connector/components/general/llm/langchain/langchain_vector_store_embedding_search.py
+++ b/src/solace_ai_connector/components/general/llm/langchain/langchain_vector_store_embedding_search.py
@@ -100,8 +100,8 @@ class LangChainVectorStoreEmbeddingsSearch(LangChainVectorStoreEmbeddingsBase):
         )
         try:
             result = self.vector_store.similarity_search(text, k=k)
-        except Exception:
-            log.error("Error while searching in the vector store")
+        except Exception as e:
+            log.error("Error while searching in the vector store", trace=e)
             raise ValueError("Error while searching in the vector store.") from None
         log.debug("Searched and got result")
         # Clean up the result by looping through all the Documents and extracting the metadata and page_content

--- a/src/solace_ai_connector/components/general/llm/litellm/litellm_base.py
+++ b/src/solace_ai_connector/components/general/llm/litellm/litellm_base.py
@@ -168,7 +168,7 @@ class LiteLLMBase(ComponentBase):
 
     def load_balance(self, messages, stream):
         """load balance the messages"""
-        model=self.load_balancer_config[0]["model_name"]
+        model = self.load_balancer_config[0]["model_name"]
         try:
             response = self.router.completion(
                 model=model,
@@ -179,12 +179,12 @@ class LiteLLMBase(ComponentBase):
         except litellm.BadRequestError as e:
             # Handle context window exceeded error
             if "ContextWindowExceededError" in str(e):
-                log.error("Context window exceeded error")
+                log.error("Context window exceeded error", trace=e)
                 return self.context_exceeded_response(model)
-            log.error("Bad request error.")
+            log.error("Bad request error.", trace=e)
             raise ValueError("Error LiteLLM bad request") from None
         except Exception as e:
-            log.error("LiteLLM API connection error.")
+            log.error("LiteLLM API connection error.", trace=e)
             raise ValueError("Error LiteLLM API connection") from None
 
         log.debug("Load balancer responded")
@@ -235,15 +235,17 @@ class LiteLLMBase(ComponentBase):
                 f"2. Splitting your request into smaller chunks\n"
                 f"3. Summarizing or extracting only the most relevant parts of your content\n\n"
                 f"Technical details: Input is too long for requested model."
-            )
+            ),
         }
         # Create a ModelResponse object with the error message
         return ModelResponse(
             id=f"context-exceeded-{int(time.time())}",
-            choices=[{
-                "message": response_message,
-                "finish_reason": "context_window_exceeded",
-                "index": 0,
-            }],
-            model=model
+            choices=[
+                {
+                    "message": response_message,
+                    "finish_reason": "context_window_exceeded",
+                    "index": 0,
+                }
+            ],
+            model=model,
         )

--- a/src/solace_ai_connector/components/general/llm/litellm/litellm_chat_model_base.py
+++ b/src/solace_ai_connector/components/general/llm/litellm/litellm_chat_model_base.py
@@ -158,10 +158,10 @@ class LiteLLMChatModelBase(LiteLLMBase):
             return {"content": response.choices[0].message.content}
         except APIConnectionError as e:
             error_str = str(e)
-            log.error("Error invoking LiteLLM")
+            log.error("Error invoking LiteLLM", trace=e)
             return {"content": error_str, "handle_error": True}
-        except Exception:
-            log.error("Error invoking LiteLLM")
+        except Exception as e:
+            log.error("Error invoking LiteLLM", trace=e)
             raise ValueError("Error invoking LiteLLM") from None
 
     def invoke_stream(self, message, messages):
@@ -222,14 +222,14 @@ class LiteLLMChatModelBase(LiteLLMBase):
 
         except APIConnectionError as e:
             error_str = str(e)
-            log.error("Error invoking LiteLLM")
+            log.error("Error invoking LiteLLM", trace=e)
             return {
                 "content": error_str,
                 "response_uuid": response_uuid,
                 "handle_error": True,
             }
-        except Exception:
-            log.error("Error invoking LiteLLM")
+        except Exception as e:
+            log.error("Error invoking LiteLLM", trace=e)
             raise ValueError("Error invoking LiteLLM") from None
 
         if self.stream_to_next_component:

--- a/src/solace_ai_connector/components/general/llm/litellm/litellm_chat_model_with_history.py
+++ b/src/solace_ai_connector/components/general/llm/litellm/litellm_chat_model_with_history.py
@@ -53,8 +53,10 @@ class LiteLLMChatModelWithHistory(LiteLLMChatModelBase, ChatHistoryHandler):
         try:
             if clear_history_but_keep_depth is not None:
                 clear_history_but_keep_depth = max(0, int(clear_history_but_keep_depth))
-        except (TypeError, ValueError):
-            log.error("Invalid clear_history_but_keep_depth value. Defaulting to 0.")
+        except (TypeError, ValueError) as e:
+            log.error(
+                "Invalid clear_history_but_keep_depth value. Defaulting to 0.", trace=e
+            )
             clear_history_but_keep_depth = 0
         messages = data.get("messages", [])
         stream = data.get("stream")

--- a/src/solace_ai_connector/components/general/llm/openai/openai_chat_model_base.py
+++ b/src/solace_ai_connector/components/general/llm/openai/openai_chat_model_base.py
@@ -179,8 +179,8 @@ class OpenAIChatModelBase(ComponentBase):
                         temperature=self.temperature,
                     )
                     return {"content": response.choices[0].message.content}
-                except Exception:
-                    log.error("Error invoking OpenAI")
+                except Exception as e:
+                    log.error("Error invoking OpenAI", trace=e)
                     max_retries -= 1
                     if max_retries <= 0:
                         raise ValueError("Max retries exceeded") from None
@@ -232,8 +232,8 @@ class OpenAIChatModelBase(ComponentBase):
                                 )
                             current_batch = ""
                             first_chunk = False
-            except Exception:
-                log.error("Error invoking OpenAI")
+            except Exception as e:
+                log.error("Error invoking OpenAI", trace=e)
                 max_retries -= 1
                 if max_retries <= 0:
                     raise ValueError("Max retries exceeded") from None

--- a/src/solace_ai_connector/components/general/websearch/web_scraper.py
+++ b/src/solace_ai_connector/components/general/websearch/web_scraper.py
@@ -50,9 +50,9 @@ class WebScraper(ComponentBase):
     def scrape(self, url):
         try:
             from playwright.sync_api import sync_playwright
-        except ImportError:
+        except ImportError as e:
             err_msg = "Please install playwright by running 'pip install playwright' and 'playwright install'."
-            log.error(err_msg)
+            log.error(err_msg, trace=e)
             raise ValueError(err_msg) from None
 
         with sync_playwright() as p:
@@ -62,9 +62,9 @@ class WebScraper(ComponentBase):
                     headless=True,
                     timeout=self.timeout,
                 )  # Set headless=False to see the browser in action
-            except ImportError:
+            except ImportError as e:
                 err_msg = "Failed to launch the Chromium instance. Please install the browser binaries by running 'playwright install'"
-                log.error(err_msg)
+                log.error(err_msg, trace=e)
                 raise ValueError(err_msg) from None
 
             resp = {}
@@ -89,8 +89,8 @@ class WebScraper(ComponentBase):
                 log.debug("Scraped the website.")
                 browser.close()
                 return resp
-            except Exception:
-                log.error("Failed to scrape the website.")
+            except Exception as e:
+                log.error("Failed to scrape the website.", trace=e)
                 browser.close()
                 return {
                     "title": "",

--- a/src/solace_ai_connector/components/inputs_outputs/broker_input.py
+++ b/src/solace_ai_connector/components/inputs_outputs/broker_input.py
@@ -94,9 +94,10 @@ class BrokerInput(BrokerBase):
             for sub_dict in initial_subscriptions:
                 if isinstance(sub_dict, dict) and "topic" in sub_dict:
                     self.active_subscriptions.add(sub_dict["topic"])
-                elif isinstance(sub_dict, str): # Support simple string list for backward compatibility
+                elif isinstance(
+                    sub_dict, str
+                ):  # Support simple string list for backward compatibility
                     self.active_subscriptions.add(sub_dict)
-
 
         self.connect()
 
@@ -141,18 +142,18 @@ class BrokerInput(BrokerBase):
             if callback is not None:
                 msg.add_negative_acknowledgements(callback)
             else:
-                log.error("No callback for negative acknowledgement found. ")
+                log.error("No callback for negative acknowledgement found.")
 
             payload = self.decode_payload(payload)
 
-            log.debug("Received message from broker.")
+            log.debug("Received message from broker.", trace=payload)
 
             # update the message with the decoded payload
             msg.payload = payload
 
             return msg
         except Exception as e:
-            log.error("Error receiving message from broker")
+            log.error("Error receiving message from broker", trace=e)
             self.handle_negative_acknowledgements(msg, e)
             raise ValueError("Error receiving message from broker") from None
 
@@ -226,8 +227,10 @@ class BrokerInput(BrokerBase):
         success = False
         # Check for SolaceMessaging-like service
         if hasattr(self.messaging_service, "add_topic_subscription"):
-            if hasattr(self.messaging_service, "persistent_receiver") and \
-               self.messaging_service.persistent_receiver is not None:
+            if (
+                hasattr(self.messaging_service, "persistent_receiver")
+                and self.messaging_service.persistent_receiver is not None
+            ):
                 success = self.messaging_service.add_topic_subscription(
                     topic_str, self.messaging_service.persistent_receiver
                 )
@@ -239,7 +242,9 @@ class BrokerInput(BrokerBase):
                 )
                 return False
         # Check for DevBrokerMessaging-like service
-        elif hasattr(self.messaging_service, "add_topic_to_queue"):  # DevBrokerMessaging
+        elif hasattr(
+            self.messaging_service, "add_topic_to_queue"
+        ):  # DevBrokerMessaging
             queue_name = self.broker_properties.get("queue_name")
             if not queue_name:
                 log.error(
@@ -283,8 +288,10 @@ class BrokerInput(BrokerBase):
         success = False
         # Check for SolaceMessaging-like service
         if hasattr(self.messaging_service, "remove_topic_subscription"):
-            if hasattr(self.messaging_service, "persistent_receiver") and \
-               self.messaging_service.persistent_receiver is not None:
+            if (
+                hasattr(self.messaging_service, "persistent_receiver")
+                and self.messaging_service.persistent_receiver is not None
+            ):
                 success = self.messaging_service.remove_topic_subscription(
                     topic_str, self.messaging_service.persistent_receiver
                 )
@@ -296,7 +303,9 @@ class BrokerInput(BrokerBase):
                 )
                 return False
         # Check for DevBrokerMessaging-like service
-        elif hasattr(self.messaging_service, "remove_topic_from_queue"):  # DevBrokerMessaging
+        elif hasattr(
+            self.messaging_service, "remove_topic_from_queue"
+        ):  # DevBrokerMessaging
             queue_name = self.broker_properties.get("queue_name")
             if not queue_name:
                 log.error(

--- a/src/solace_ai_connector/components/inputs_outputs/broker_output.py
+++ b/src/solace_ai_connector/components/inputs_outputs/broker_output.py
@@ -109,7 +109,7 @@ class BrokerOutput(BrokerBase):
             log.info("Discarding message due to TTL expiration.")
             return
 
-        log.debug("Sending message to broker.")
+        log.debug("Sending message to broker.", trace=message)
         user_context = None
         if self.propagate_acknowledgements:
             user_context = {

--- a/src/solace_ai_connector/components/inputs_outputs/broker_request_response.py
+++ b/src/solace_ai_connector/components/inputs_outputs/broker_request_response.py
@@ -311,8 +311,8 @@ class BrokerRequestResponse(BrokerBase):
                 )
                 if broker_message:
                     self.process_response(broker_message)
-            except Exception:
-                log.error("Error handling response.")
+            except Exception as e:
+                log.error("Error handling response.", trace=e)
 
     def handle_test_pass_through(self):
         while not self.stop_signal.is_set():
@@ -321,10 +321,11 @@ class BrokerRequestResponse(BrokerBase):
                 decoded_payload = self.decode_payload(message.get_payload())
                 message.set_payload(decoded_payload)
                 self.process_response(message)
-            except queue.Empty:
+            except queue.Empty as e:
+                log.debug("No messages in pass-through queue.", trace=e)
                 continue
-            except Exception:
-                log.error("Error handling test passthrough.")
+            except Exception as e:
+                log.error("Error handling test passthrough.", trace=e)
 
     def process_response(self, broker_message):
         if self.test_mode:
@@ -353,8 +354,8 @@ class BrokerRequestResponse(BrokerBase):
 
         try:
             metadata_stack = json.loads(metadata_json)
-        except json.JSONDecodeError:
-            log.error("Received response with invalid metadata JSON.")
+        except json.JSONDecodeError as e:
+            log.error("Received response with invalid metadata JSON.", trace=e)
             return
 
         if not metadata_stack:
@@ -363,8 +364,8 @@ class BrokerRequestResponse(BrokerBase):
 
         try:
             current_metadata = metadata_stack.pop()
-        except IndexError:
-            log.error("Received response with invalid metadata stack.")
+        except IndexError as e:
+            log.error("Received response with invalid metadata stack.", trace=e)
             return
         request_id = current_metadata.get("request_id")
         if not request_id:

--- a/src/solace_ai_connector/components/inputs_outputs/websocket_base.py
+++ b/src/solace_ai_connector/components/inputs_outputs/websocket_base.py
@@ -108,11 +108,11 @@ class WebsocketBase(ComponentBase, ABC):
 
     def run_server(self):
         if self.socketio:
-            self.http_server = WSGIServer(('0.0.0.0', self.listen_port), self.app)
+            self.http_server = WSGIServer(("0.0.0.0", self.listen_port), self.app)
             self.http_server.serve_forever()
 
     def stop_server(self):
-        if hasattr(self, 'http_server') and self.http_server.started:
+        if hasattr(self, "http_server") and self.http_server.started:
             try:
                 self.http_server.stop(timeout=10)
             except Exception as e:
@@ -121,7 +121,7 @@ class WebsocketBase(ComponentBase, ABC):
             self.socketio.stop()
         except Exception as e:
             pass
-          
+
     def get_sockets(self):
         if not self.sockets:
             self.sockets = self.kv_store_get("websocket_connections") or {}
@@ -132,10 +132,12 @@ class WebsocketBase(ComponentBase, ABC):
         if socket_id == "*":
             for socket in sockets.values():
                 socket.emit("message", payload)
-            log.debug("Message sent to all WebSocket connections")
+            log.debug("Message sent to all WebSocket connections", trace=payload)
         elif socket_id in sockets:
             sockets[socket_id].emit("message", payload)
-            log.debug("Message sent to WebSocket connection %s", socket_id)
+            log.debug(
+                "Message sent to WebSocket connection %s", socket_id, trace=payload
+            )
         else:
             log.error("No active connection found for socket_id: %s", socket_id)
             return False

--- a/src/solace_ai_connector/components/inputs_outputs/websocket_input.py
+++ b/src/solace_ai_connector/components/inputs_outputs/websocket_input.py
@@ -60,13 +60,15 @@ class WebsocketInput(WebsocketBase):
                 )
                 event = Event(EventType.MESSAGE, message)
                 self.process_event_with_tracing(event)
-            except json.JSONDecodeError:
-                log.error("Received invalid payload.")
+            except json.JSONDecodeError as e:
+                log.error("Received invalid payload.", trace=e)
             except AssertionError as e:
+                log.error("Error in payload format.", trace=e)
                 raise AssertionError(
                     "Error Payload format. Please check the payload format."
                 ) from None
             except Exception as e:
+                log.error("Error processing WebSocket message.", trace=e)
                 self.handle_component_error(e, event)
 
     def run(self):
@@ -82,6 +84,6 @@ class WebsocketInput(WebsocketBase):
                 "topic": message.get_topic(),
                 "user_properties": message.get_user_properties(),
             }
-        except Exception:
-            log.error("Error processing WebSocket message.")
+        except Exception as e:
+            log.error("Error processing WebSocket message.", trace=e)
             return None

--- a/src/solace_ai_connector/components/inputs_outputs/websocket_output.py
+++ b/src/solace_ai_connector/components/inputs_outputs/websocket_output.py
@@ -69,8 +69,8 @@ class WebsocketOutput(WebsocketBase):
                 self.discard_current_message()
                 return None
 
-        except Exception:
-            log.error("Error sending message via WebSocket.")
+        except Exception as e:
+            log.error("Error sending message via WebSocket.", trace=e)
             self.discard_current_message()
             return None
 

--- a/src/solace_ai_connector/flow/app.py
+++ b/src/solace_ai_connector/flow/app.py
@@ -114,10 +114,10 @@ class App:
                 # Store controller instance (already done by assignment above)
             except Exception as e:
                 log.error(
-                    "Failed to initialize RequestResponseFlowController for app '%s': %s",
+                    "Failed to initialize RequestResponseFlowController for app '%s'.",
                     self.name,
-                    e,
                     exc_info=True,
+                    trace=e,
                 )
                 # Decide if this should be a fatal error for the app
                 raise e
@@ -208,8 +208,8 @@ class App:
                 self.flow_input_queues[flow_config.get("name")] = flow_input_queue
                 self.flows.append(flow_instance)
 
-        except Exception:
-            log.error("Error initializing flows for app", self.name)
+        except Exception as e:
+            log.error("Error initializing flows for app", self.name, trace=e)
             raise ValueError(
                 f"Error initializing flows for app '{self.name}'. Check the configuration."
             )
@@ -354,17 +354,17 @@ class App:
                 pass  # RRC's internal app/flow will be cleaned by connector.cleanup()
             except Exception as e:
                 log.error(
-                    "Error cleaning up RequestResponseFlowController in app %s: %s",
+                    "Error cleaning up RequestResponseFlowController in app %s",
                     self.name,
-                    e,
+                    trace=e,
                 )
             self.request_response_controller = None
 
         for flow in self.flows:
             try:
                 flow.cleanup()
-            except Exception:
-                log.error(f"Error cleaning up flow in app {self.name}")
+            except Exception as e:
+                log.error(f"Error cleaning up flow in app {self.name}", trace=e)
         self.flows.clear()
         self.flow_input_queues.clear()
         self._broker_output_component = None  # Clear cache
@@ -460,9 +460,9 @@ class App:
             self._broker_output_component.enqueue(event)
         except Exception as e:
             log.error(
-                "App '%s' failed to enqueue message to BrokerOutput: %s",
+                "App '%s' failed to enqueue message to BrokerOutput.",
                 self.name,
-                e,
+                trace=e,
                 exc_info=True,
             )
 

--- a/src/solace_ai_connector/flow/subscription_router.py
+++ b/src/solace_ai_connector/flow/subscription_router.py
@@ -73,10 +73,11 @@ class SubscriptionRouter(ComponentBase):
             # Access the flow this component belongs to via the parent app
             flow = self.get_app().flows[0]
             flow_component_groups = flow.component_groups
-        except (AttributeError, IndexError):
+        except (AttributeError, IndexError) as e:
             log.error(
                 "%s Could not access flow component groups. Cannot build routing targets.",
                 self.log_identifier,
+                trace=e,
             )
             return
 
@@ -148,11 +149,11 @@ class SubscriptionRouter(ComponentBase):
                         regex_list.append(re.compile(regex_str))
                     except re.error as e:
                         log.error(
-                            "%s Invalid regex generated from subscription '%s' for component '%s': %s",
+                            "%s Invalid regex generated from subscription '%s' for component '%s'",
                             self.log_identifier,
                             topic,
                             comp_name,
-                            e,
+                            trace=e,
                         )
 
             if regex_list:
@@ -188,6 +189,7 @@ class SubscriptionRouter(ComponentBase):
             "%s Attempting to route message with topic: '%s'",
             self.log_identifier,
             msg_topic,
+            trace=message,
         )
 
         for target_component, regex_list in self.component_targets:
@@ -217,6 +219,7 @@ class SubscriptionRouter(ComponentBase):
                             target_component.name,
                             e,
                             exc_info=True,
+                            trace=e,
                         )
                         # Let error handling proceed (ComponentBase will NACK original message)
                         raise e

--- a/src/solace_ai_connector/solace_ai_connector.py
+++ b/src/solace_ai_connector/solace_ai_connector.py
@@ -62,8 +62,8 @@ class SolaceAiConnector:
             log.info("Received keyboard interrupt - stopping")
 
             raise KeyboardInterrupt from None
-        except Exception:
-            log.error("Error during Solace AI Event Connector startup")
+        except Exception as e:
+            log.error("Error during Solace AI Event Connector startup", trace=e)
             raise ValueError("An error occurred during startup") from None
 
     def create_apps(self):
@@ -192,8 +192,8 @@ class SolaceAiConnector:
         except KeyboardInterrupt:
             log.info("Received keyboard interrupt - stopping")
             raise KeyboardInterrupt from None
-        except Exception:
-            log.error("Error creating apps")
+        except Exception as e:
+            log.error("Error creating apps", trace=e)
             raise ValueError("An error occurred during app creation") from None
 
     def create_internal_app(self, app_name: str, flows: List[Dict[str, Any]]) -> App:
@@ -284,8 +284,8 @@ class SolaceAiConnector:
         for app in self.apps:
             try:
                 app.cleanup()
-            except Exception:
-                log.error("Error cleaning up app")
+            except Exception as e:
+                log.error("Error cleaning up app", trace=e)
         self.apps.clear()
         self.flows.clear()  # Keep for backward compatibility refs?
 
@@ -294,8 +294,8 @@ class SolaceAiConnector:
             try:
                 while not queue.empty():
                     queue.get_nowait()
-            except Exception:
-                log.error(f"Error cleaning queue {queue_name}")
+            except Exception as e:
+                log.error(f"Error cleaning queue {queue_name}", trace=e)
         self.flow_input_queues.clear()
 
         if hasattr(self, "trace_queue") and self.trace_queue:
@@ -321,6 +321,7 @@ class SolaceAiConnector:
         log_file_level = log_config.get("log_file_level", "INFO")
         log_file = log_config.get("log_file", "solace_ai_connector.log")
         log_format = log_config.get("log_format", "pipe-delimited")
+        enable_trace = log_config.get("enable_trace", True)
 
         # Get logback values
         logback = log_config.get("logback", {})
@@ -331,6 +332,7 @@ class SolaceAiConnector:
             log_file_level,
             log_format,
             logback,
+            enable_trace,
         )
 
     def setup_trace(self):
@@ -372,8 +374,8 @@ class SolaceAiConnector:
                         if self.stop_signal.is_set():
                             break
                         continue
-        except Exception:
-            log.error("Error in trace handler thread")
+        except Exception as e:
+            log.error("Error in trace handler thread", trace=e)
 
     def validate_config(self):
         """Validate the configuration structure."""

--- a/src/solace_ai_connector/test_utils/utils_for_test_files.py
+++ b/src/solace_ai_connector/test_utils/utils_for_test_files.py
@@ -52,7 +52,7 @@ class TestInputComponent:
         self.next_component_queue = next_component_queue
 
     def enqueue(self, message):
-        log.debug("Input test component sending message.")
+        log.debug("Input test component sending message.", trace=message)
         if not isinstance(message, Event):
             event = Event(EventType.MESSAGE, message)
         else:


### PR DESCRIPTION
**What is the purpose of this change?**

We need to record the stack of exceptions for debugging issues.

**How is this accomplished?**

Overwrote the debug and error logs to get a trace and record it in a log file if  `enable_trace` flag is active. When this flag is disabled, logs record messages without traces.

**Anything reviews should focus on/be aware of?**

Reviewers should verify that all `log.error` and` log.debugs` commands have a correct signature.
