### PR TITLE
DATAGO-103171 : hot fix flow index issue (#130)

### DIFF
--- a/src/solace_ai_connector/flow/app.py
+++ b/src/solace_ai_connector/flow/app.py
@@ -182,9 +182,15 @@ class App:
                     for i in range(num_instances):
                         flow_instance = self.create_flow(flow_config, index, i)
                         flow_input_queue = flow_instance.get_flow_input_queue()
-                        # Use flow name and instance index for unique queue key if needed
-                        queue_key = f"{flow_config.get('name')}_{i}"
-                        self.flow_input_queues[queue_key] = flow_input_queue
+                         # Use flow name without index for single instance flows
+                        flow_name = flow_config.get('name')
+                        if num_instances == 1:
+                            # For single instance flows, don't add an index
+                            self.flow_input_queues[flow_name] = flow_input_queue
+                        else:
+                            # For multiple instances, add an index
+                            queue_key = f"{flow_name}_{i}"
+                            self.flow_input_queues[queue_key] = flow_input_queue
                         self.flows.append(flow_instance)
             else:
                 # --- Simplified App Mode ---

--- a/tests/components/general/llm/litellm/conftest.py
+++ b/tests/components/general/llm/litellm/conftest.py
@@ -1,19 +1,40 @@
-"""Pytest fixtures for LLM component tests."""
+"""Pytest fixtures for LiteLLM component tests."""
 
-# Removed sys.path manipulations.
-# It's expected that the project is installed in editable mode
-# in the test environment (e.g., via 'pip install -e .'),
-# making 'solace_ai_connector' directly importable.
-
+import sys
+import os
 import pytest
 from unittest.mock import patch
 from threading import Lock  # Keep this import for fixtures if they create Locks directly
+
+# Add the src directory to the path so we can import solace_ai_connector
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', '..', '..', '..', 'src'))
 
 from solace_ai_connector.common.message import Message
 from solace_ai_connector.components.general.llm.litellm.litellm_base import (
     litellm_info_base as litellm_base_module_info_dict,
 )
 from solace_ai_connector.common.monitoring import Metrics
+from solace_ai_connector.common.log import setup_log, log
+
+
+@pytest.fixture(autouse=True)
+def setup_litellm_logging():
+    """Set up logging with trace enabled for LiteLLM tests."""
+    # Reset any handlers that might be attached to the logger
+    for handler in log.handlers[:]:
+        log.removeHandler(handler)
+    
+    # Set up logging with trace enabled
+    setup_log(
+        logFilePath="litellm_test_logs.log",
+        stdOutLogLevel="INFO",
+        fileLogLevel="DEBUG",
+        logFormat="pipe-delimited",
+        logBack={},
+        enableTrace=True
+    )
+    
+    yield
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,35 @@
+"""Pytest fixtures for all tests."""
+
+import sys
+import os
+import pytest
+
+# Add the src directory to the path so we can import solace_ai_connector
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from solace_ai_connector.common.log import setup_log, log
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_logging():
+    """Set up logging with trace enabled for all tests."""
+    # Reset any handlers that might be attached to the logger
+    for handler in log.handlers[:]:
+        log.removeHandler(handler)
+    
+    # Set up logging with trace enabled
+    setup_log(
+        logFilePath="test_logs.log",
+        stdOutLogLevel="INFO",
+        fileLogLevel="DEBUG",
+        logFormat="pipe-delimited",
+        logBack={},
+        enableTrace=True
+    )
+    
+    yield
+    
+    # Clean up if needed
+    for handler in log.handlers[:]:
+        handler.close()
+        log.removeHandler(handler)

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -45,7 +45,7 @@ log:
         )
     except ValueError as e:
         # Update assertion to match actual error message
-        assert str(e) == "No 'apps' or 'flows' defined in configuration file"
+        assert str(e) == "No apps or flows defined in configuration file"
 
 
 def test_no_flow_name():


### PR DESCRIPTION
### What is the purpose of this change?
The AI Connector adds an index to workflow names while initializing workflows; however, it cannot find the indexed workflows.

### How is this accomplished?
Handled workflow naming and discovery. If there is only one instance of workflow, it does not add an index, otherwise it appends indexes to workflow names. During discovery, it checks indexes and randomly distribute requests to instances of workflows.

### Anything reviews should focus on/be aware of?