### PR TITLE
Relax version on request dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "PyYAML==6.0.2",
-    "Requests==2.32.3",
+    "Requests~=2.32.3",
     "solace_pubsubplus==1.9.0",
     "SQLAlchemy==2.0.40",
     'pywin32>=306; sys_platform == "win32"',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-/build-system]
+[build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-[build-system]
+/build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
@@ -215,7 +215,7 @@ qdrant_ext_release = [
     "pydantic_core==2.33.1",
     "PyYAML==6.0.2",
     "qdrant-client==1.13.3",
-    "requests~=2.32.3",
+    "requests==2.32.3",
     "requests-toolbelt==1.0.0",
     "setuptools==78.1.0",
     "sniffio==1.3.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,7 +215,7 @@ qdrant_ext_release = [
     "pydantic_core==2.33.1",
     "PyYAML==6.0.2",
     "qdrant-client==1.13.3",
-    "requests==2.32.3",
+    "requests~=2.32.3",
     "requests-toolbelt==1.0.0",
     "setuptools==78.1.0",
     "sniffio==1.3.1",


### PR DESCRIPTION
<!-- Example: 🟢 Low / 🟡 Medium / 🔴 High -->
🧩 Complexity Level: 🟢 Low

 <!-- Example: 5-10 minutes -->
⏱️ Estimated Review Time: 10–15 minutes

### What is the purpose of this change?
Many AI tools use the request dependency and having such a rigid version constraint limits where the solace-ai-connector can be used.

### How is this accomplished?
Relax the constraint with ~= instead of ==

### Anything reviews should focus on/be aware of?
No
