### PR TITLE
feat(DATAGO-111686): Add multi-session-request-response and more logging config

### DIFF
--- a/docs/guides/broker_request_response.md
+++ b/docs/guides/broker_request_response.md
@@ -1,0 +1,427 @@
+# Broker Request-Response Guide
+
+This guide provides comprehensive documentation for the broker request-response capabilities in the Solace AI Connector. It covers both the default single-session mode and the advanced multi-session mode, enabling synchronous (blocking) and asynchronous (non-blocking) communication patterns.
+
+## Table of Contents
+1.  [Introduction](#introduction)
+2.  [Modes of Operation](#modes-of-operation)
+    -   [Single-Session Mode (Default)](#single-session-mode-default)
+    -   [Multi-Session Mode (Advanced)](#multi-session-mode-advanced)
+3.  [Choosing Between Modes](#choosing-between-modes)
+4.  [API Reference](#api-reference)
+    -   [`do_broker_request_response()`](#do_broker_request_response)
+    -   [`create_request_response_session()`](#create_request_response_session)
+    -   [`destroy_request_response_session()`](#destroy_request_response_session)
+    -   [`list_request_response_sessions()`](#list_request_response_sessions)
+5.  [Use Cases and Examples](#use-cases-and-examples)
+    -   [Synchronous Request-Response](#synchronous-request-response)
+    -   [Streaming Response](#streaming-response)
+    -   [Asynchronous Request (Fire-and-Forget)](#asynchronous-request-fire-and-forget)
+    -   [Dynamic Multi-Session Usage](#dynamic-multi-session-usage)
+6.  [Error Handling and Troubleshooting](#error-handling-and-troubleshooting)
+
+---
+
+## 1. Introduction
+
+The request-response feature allows a component to send a request message to a topic and receive a correlated response. The framework handles the complexity of correlation, reply topics, and timeouts.
+
+This capability supports two main interaction patterns:
+-   **Synchronous (Blocking):** The component sends a request and waits for a reply before continuing. This is the default behavior.
+-   **Asynchronous (Non-Blocking):** The component sends a request and immediately continues processing without waiting for a reply. This is ideal for "fire-and-forget" scenarios.
+
+## 2. Modes of Operation
+
+Request-response can be configured in two primary modes.
+
+### Single-Session Mode (Default)
+
+This is the simplest and recommended approach for most use cases. A single, shared request-response session is created for the entire application, using the app's main broker configuration.
+
+-   **Overview**: One shared session per app.
+-   **Configuration**: Enabled at the app level in your `config.yaml`.
+-   **Use Cases**: Standard request-response needs where all components in an app can share the same broker connection for requests.
+
+#### Configuration
+
+Enable this mode by setting `request_reply_enabled: true` in the `broker:` section of a simplified app.
+
+```yaml
+# config.yaml
+apps:
+  - name: my_requesting_app
+    broker:
+      broker_url: "${SOLACE_BROKER_URL}"
+      broker_username: "${SOLACE_USERNAME}"
+      broker_password: "${SOLACE_PASSWORD}"
+      broker_vpn: "${SOLACE_VPN}"
+      input_enabled: true
+      # Enable the shared request-response session for this app
+      request_reply_enabled: true
+    components:
+      - name: my_component
+        component_module: my_requesting_component
+        # ...
+```
+
+### Multi-Session Mode (Advanced)
+
+This mode allows a single component to create and manage multiple, independent request-response sessions. Each session can have its own unique broker configuration (e.g., connect to different brokers or use different client settings).
+
+-   **Overview**: A component manages multiple, independent sessions.
+-   **Configuration**: Enabled at the component level in your `config.yaml`.
+-   **Use Cases**: Multi-tenant scenarios, connecting to different broker environments from one component, or requiring isolated sessions for reliability.
+
+#### Configuration
+
+Enable this mode by adding a `multi_session_request_response` block to a component's configuration.
+
+A default broker configuration is **optional**.
+
+-   If a default is provided (either explicitly via `default_broker_config` or inherited from the parent app's `broker` section), new sessions can be created without specifying connection details.
+-   If no default is provided, every call to `create_request_response_session()` **must** include a complete `broker_config` in the `session_config_overrides`.
+
+**Example 1: Inheriting from App's Broker Config (Recommended)**
+
+If the component is in an app with a defined `broker` section, you only need to enable the feature.
+
+```yaml
+# config.yaml
+apps:
+  - name: my_app
+    broker:
+      # This configuration will be used as the default for multi-session
+      broker_url: "${SOLACE_BROKER_URL}"
+      broker_username: "${SOLACE_USERNAME}"
+      broker_password: "${SOLACE_PASSWORD}"
+      broker_vpn: "${SOLACE_VPN}"
+    components:
+      - name: my_component
+        component_module: my_module
+        component_config:
+          multi_session_request_response:
+            enabled: true
+            max_sessions: 10 # Optional: default is 50
+```
+
+**Example 2: Explicitly Defining a Default Broker Config**
+
+This is useful if the component needs to use a different default broker than the parent app, or if the app has no `broker` section.
+
+```yaml
+# config.yaml
+apps:
+  - name: my_multi_session_app
+    # ...
+    flows:
+      - name: my_flow
+        components:
+          - component_name: my_advanced_component
+            component_module: my_advanced_component
+            component_config:
+              multi_session_request_response:
+                enabled: true
+                max_sessions: 10
+                default_broker_config:
+                  # Explicit default connection details for new sessions
+                  broker_url: "tcp://another-broker:55555"
+                  broker_username: "session_user"
+                  broker_password: "session_pass"
+                  broker_vpn: "session_vpn"
+```
+
+---
+
+## 3. Choosing Between Modes
+
+| Feature | Single-Session Mode | Multi-Session Mode |
+| :--- | :--- | :--- |
+| **Configuration** | App-level (`request_reply_enabled: true`) | Component-level (`multi_session_request_response`) |
+| **Session Management** | Automatic (managed by the framework) | Manual (via `create/destroy` API calls) |
+| **Use Case** | Simple, default request-response needs. | Advanced, multi-tenant, multi-broker scenarios. |
+| **Resource Overhead**| Low (one shared session per app) | Higher (one session per `create` call) |
+| **Primary API** | `self.do_broker_request_response(message)` | `self.do_broker_request_response(message, session_id=...)` |
+
+---
+
+## 4. API Reference
+
+These methods are available on your component instance (`self`).
+
+### `do_broker_request_response()`
+
+Performs the request-response operation. This is the primary method for both single-session and multi-session modes.
+
+```python
+self.do_broker_request_response(
+    message,
+    session_id: Optional[str] = None,
+    stream: bool = False,
+    streaming_complete_expression: Optional[str] = None,
+    wait_for_response: bool = True
+)
+```
+
+**Parameters:**
+
+-   `message` (`Message`): The request message object containing the payload, topic, and optional user properties.
+-   `session_id` (`str`, optional): The ID of a dynamic session to use. **If provided, multi-session mode is used.** If `None`, the default single-session mode is used.
+-   `stream` (`bool`, optional): Set to `True` to indicate that the response will arrive in multiple parts (chunks). Defaults to `False`.
+-   `streaming_complete_expression` (`str`, optional): **Required if `stream=True`**. An expression that evaluates to `True` on the final chunk of a streaming response.
+-   `wait_for_response` (`bool`, optional):
+    -   `True` (Default): The call blocks until a response is received or a timeout occurs.
+    -   `False`: The call sends the request and returns `None` immediately ("fire-and-forget").
+
+**Return Value:**
+
+-   If `wait_for_response=False`: Returns `None`.
+-   If `wait_for_response=True` and `stream=False`: Returns the single response `Message` object, or raises a `TimeoutError`.
+-   If `wait_for_response=True` and `stream=True`: Returns a Python generator that yields tuples of `(chunk_message, is_last)`.
+
+### `do_broker_request_response_async()`
+
+An `async` wrapper for the standard request-response method. Use this version with `await` when calling from an `async` function to avoid blocking the event loop.
+
+```python
+await self.do_broker_request_response_async(...)
+```
+
+It accepts the exact same parameters as its synchronous counterpart and works for both blocking and fire-and-forget patterns.
+
+### `create_request_response_session()`
+
+Creates a new, dynamic request-response session. **Only available in multi-session mode.**
+
+```python
+self.create_request_response_session(
+    session_config: Optional[Dict[str, Any]] = None
+) -> str
+```
+-   **`session_config`**: A dictionary of configuration values for this session. These values are merged with any defaults.
+-   **Returns**: A unique `session_id` (string) for the new session.
+
+The `session_config` dictionary can contain the following keys to customize the session's behavior. Any values not provided will fall back to the component's default configuration, if one is defined.
+
+| Key | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `broker_config` | `dict` | (Inherited) | A dictionary containing broker connection details, such as `broker_url`, `broker_username`, `broker_password`, and `broker_vpn`. |
+| `payload_encoding` | `str` | `"utf-8"` | The encoding for the message payload (e.g., `utf-8`, `base64`). |
+| `payload_format` | `str` | `"json"` | The format of the message payload (e.g., `json`, `text`, `yaml`). |
+| `request_expiry_ms` | `int` | `30000` | Timeout in milliseconds for a request to receive a response. |
+| `response_topic_prefix` | `str` | `"reply"` | The prefix used for the session's unique reply topic. |
+| `response_queue_prefix` | `str` | `"reply-queue"` | The prefix used for the session's unique reply queue. |
+| `max_concurrent_requests` | `int` | `100` | The maximum number of outstanding requests allowed for this session. |
+| `user_properties_reply_topic_key` | `str` | `__solace_ai_...` | The key used to store the reply topic in the request message's user properties. |
+| `response_topic_insertion_expression` | `str` | `""` | An expression to insert the reply topic directly into the request message's payload (e.g., `input.payload:reply_to`). |
+
+
+### `destroy_request_response_session()`
+
+Destroys a dynamic session and cleans up its resources. **Only available in multi-session mode.** It is critical to call this to prevent resource leaks.
+
+```python
+self.destroy_request_response_session(session_id: str) -> bool
+```
+-   **`session_id`**: The ID of the session to destroy.
+-   **Returns**: `True` if the session was found and destroyed, `False` otherwise.
+
+### `list_request_response_sessions()`
+
+Lists all active dynamic sessions managed by the component. **Only available in multi-session mode.**
+
+```python
+self.list_request_response_sessions() -> List[Dict[str, Any]]
+```
+-   **Returns**: A list of dictionaries, each containing status information about an active session.
+
+---
+
+## 5. Use Cases and Examples
+
+### Synchronous Request-Response
+
+The component sends a request and waits for a single reply.
+
+```python
+# In your component's invoke method
+from solace_ai_connector.common.message import Message
+
+request_message = Message(payload={"query": "user_profile", "id": 123}, topic="service/request")
+
+try:
+    # This call will block until a response is received or it times out
+    response_message = self.do_broker_request_response(request_message)
+    if response_message:
+        log.info(f"Received response: {response_message.get_payload()}")
+        return response_message.get_payload()
+except TimeoutError:
+    log.error("Request for user profile timed out.")
+    return {"error": "timeout"}
+```
+
+### Streaming Response
+
+The component receives multiple chunks of a response and aggregates them.
+
+```python
+# In your component's invoke method
+request_message = Message(payload={"prompt": "Tell me a long story"}, topic="llm/request/stream")
+
+# This expression will be evaluated on each response chunk.
+# The stream ends when a chunk's payload contains `{"done": true}`.
+streaming_complete_expr = "input.payload:done"
+
+try:
+    response_generator = self.do_broker_request_response(
+        request_message,
+        stream=True,
+        streaming_complete_expression=streaming_complete_expr
+    )
+
+    full_story = ""
+    for chunk_message, is_last in response_generator:
+        chunk_payload = chunk_message.get_payload()
+        full_story += chunk_payload.get("text", "")
+        if is_last:
+            log.info("Final chunk received. Story is complete.")
+            break
+
+    return {"story": full_story}
+except TimeoutError:
+    log.error("Streaming request timed out.")
+    return {"error": "timeout"}
+```
+
+### Asynchronous Request (Fire-and-Forget)
+
+This pattern allows a component to send a request and continue processing immediately, while a separate flow handles the reply.
+
+**1. The Requesting Component**
+
+The requesting component sets `wait_for_response=False`.
+
+```python
+# In a component in a "requester" app
+def invoke(self, message, data):
+    request_message = Message(payload={"command": "start_batch_job"}, topic="jobs/control")
+
+    # This call returns immediately
+    self.do_broker_request_response(
+        request_message,
+        wait_for_response=False
+    )
+
+    log.info("Sent 'start_batch_job' command and continued processing.")
+    return None # End of this flow
+```
+
+**2. The Reply-Handling Flow**
+
+A completely separate flow must be configured to listen for the asynchronous replies. The reply topic is determined by the request-response controller's configuration (e.g., `reply/...`).
+
+```yaml
+# In config.yaml, a separate app/flow to handle replies
+apps:
+  - name: "reply_handler_app"
+    broker:
+      broker_url: "${SOLACE_BROKER_URL}"
+      broker_username: "${SOLACE_USERNAME}"
+      broker_password: "${SOLACE_PASSWORD}"
+      broker_vpn: "${SOLACE_VPN}"
+      input_enabled: true
+      queue_name: "async_replies_queue"
+    components:
+      - name: "reply_processor"
+        component_module: "user_processor"
+        subscriptions:
+          # Subscribe to the reply topic pattern used by the request-response controller
+          - topic: "reply/>"
+        component_config:
+          component_processing: |
+            def process_reply(message):
+                log.info(f"Received async reply: {message.get_payload()}")
+                # Further processing of the reply...
+                return None # End of flow
+```
+
+### Dynamic Multi-Session Usage
+
+This example shows how a component can manage sessions for different tenants.
+
+```python
+# In an advanced component with multi-session mode enabled
+def invoke(self, message, data):
+    tenant_id = data.get("tenant_id")
+    tenant_broker_url = self.get_tenant_broker_url(tenant_id) # Your logic to get tenant config
+
+    # Create a session for this tenant if it doesn't exist
+    session_id = self.kv_store_get(f"session_{tenant_id}")
+    if not session_id:
+        log.info(f"Creating new session for tenant {tenant_id}")
+        # Create a new session with tenant-specific configuration
+        session_id = self.create_request_response_session(
+            session_config={
+                "broker_config": {
+                    "broker_url": tenant_broker_url,
+                    "broker_vpn": f"vpn-for-{tenant_id}"
+                    # Other broker settings can be provided here
+                },
+                "request_expiry_ms": 60000, # Longer timeout for this tenant
+                "response_topic_prefix": f"replies/tenant/{tenant_id}"
+            }
+        )
+        self.kv_store_set(f"session_{tenant_id}", session_id)
+
+    # Use the specific session for the request
+    request_message = Message(payload=data.get("payload"), topic="tenant/service")
+    try:
+        response = self.do_broker_request_response(request_message, session_id=session_id)
+        return response.get_payload()
+    except Exception as e:
+        log.error(f"Error on session {session_id} for tenant {tenant_id}: {e}")
+        # Optionally, destroy and recreate the session on failure
+        self.destroy_request_response_session(session_id)
+        self.kv_store_set(f"session_{tenant_id}", None)
+        raise
+```
+
+### Usage from an Async Context
+
+If your component's logic uses `asyncio`, you **must** use the `do_broker_request_response_async` method with `await` to prevent blocking the event loop. The framework will automatically run the underlying blocking operation in a separate thread.
+
+```python
+# In your component's code
+import asyncio
+from solace_ai_connector.common.message import Message
+
+async def my_async_logic(self, data):
+    request_msg = Message(payload=data, topic="service/request")
+
+    # Correctly await the async version of the method
+    response_msg = await self.do_broker_request_response_async(request_msg)
+
+    if response_msg:
+        return response_msg.get_payload()
+    return None
+
+def invoke(self, message, data):
+    # You can run your async logic from the synchronous invoke method
+    return asyncio.run(self.my_async_logic(data))
+```
+
+---
+
+## 6. Error Handling and Troubleshooting
+
+When using request-response, be prepared to handle the following:
+
+-   `TimeoutError`: Raised if a response is not received within the configured `request_expiry_ms`.
+-   `SessionLimitExceededError`: (Multi-session) Raised by `create_request_response_session` if `max_sessions` is reached.
+-   `SessionNotFoundError`: (Multi-session) Raised if a `session_id` is provided to `do_broker_request_response` or `destroy_request_response_session` that does not exist.
+-   `SessionClosedError`: (Multi-session) Raised if an operation is attempted on a session that has been closed or has expired.
+
+**Common Issues:**
+
+-   **Resource Leaks (Multi-Session):** Forgetting to call `destroy_request_response_session` will lead to orphaned connections, threads, and queues on the broker. Always ensure sessions are cleaned up, perhaps in a `finally` block or a component `cleanup` method.
+-   **Incorrect `streaming_complete_expression`:** If this expression never evaluates to true, a streaming request will always time out. Ensure the replying service sets the flag correctly in the last message.
+-   **No Reply Handler for Fire-and-Forget:** When using `wait_for_response=False`, ensure you have a separate flow subscribed to the correct reply topic to process the responses, or they will be discarded by the broker.

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ This connector application makes it easy to connect your AI/ML models to Solace 
 - [Custom Components](custom_components.md)
 - [Tips and Tricks](tips_and_tricks.md)
 - [Guides](guides/index.md)
+  - [Broker Request-Response](guides/broker_request_response.md)
 - [Examples](../examples/)
 - [Contributing](../CONTRIBUTING.md)
 - [License](../LICENSE)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,6 +257,7 @@ test = [
     "pytest>=8.0.0", # Example version, adjust as needed
     "pytest-mock>=3.0.0", # Example version
     "pytest-cov>=4.0.0", # If you use coverage
+    "pytest-asyncio>=1.2.0",
     # Add other test-specific dependencies here
 ]
 
@@ -337,7 +338,8 @@ dependencies = [
   "pytest>=8.0.0",
   "pytest-mock>=3.0.0",
   "pytest-cov>=4.0.0",
-  "pytest-xdist>=3.5.0"
+  "pytest-xdist>=3.5.0",
+  "pytest-asyncio>=1.2.0"
 ]
 extra-dependencies = [
    "solace_ai_connector[all]"

--- a/src/solace_ai_connector/common/exceptions.py
+++ b/src/solace_ai_connector/common/exceptions.py
@@ -1,0 +1,19 @@
+"""Custom exceptions for the Solace AI Connector."""
+
+
+class SessionLimitExceededError(Exception):
+    """Raised when the maximum number of request/reply sessions is reached."""
+
+    pass
+
+
+class SessionClosedError(Exception):
+    """Raised when an operation is attempted on a closed or expired session."""
+
+    pass
+
+
+class SessionNotFoundError(ValueError):
+    """Raised when a specified session_id does not exist."""
+
+    pass

--- a/src/solace_ai_connector/common/session_config.py
+++ b/src/solace_ai_connector/common/session_config.py
@@ -1,0 +1,86 @@
+"""Session configuration for the Solace AI Connector."""
+
+from dataclasses import dataclass, asdict, fields
+from typing import Dict, Any, Optional
+
+
+@dataclass
+class SessionConfig:
+    """
+    Configuration for a request/response session.
+
+    All configuration is stored as immutable dataclass fields.
+    """
+
+    broker_config: Dict[str, Any]
+    payload_encoding: str = "utf-8"
+    payload_format: str = "json"
+    request_expiry_ms: int = 30000
+    response_topic_prefix: str = "reply"
+    response_queue_prefix: str = "reply-queue"
+    max_concurrent_requests: int = 100
+    user_properties_reply_topic_key: str = (
+        "__solace_ai_connector_broker_request_response_topic__"
+    )
+    user_properties_reply_metadata_key: str = (
+        "__solace_ai_connector_broker_request_reply_metadata__"
+    )
+    response_topic_insertion_expression: str = ""
+
+    def __post_init__(self):
+        """Validate the configuration after initialization."""
+        self.validate()
+
+    def to_controller_config(self) -> Dict[str, Any]:
+        """Converts the SessionConfig to a dictionary for RequestResponseFlowController."""
+        config = asdict(self)
+        # The controller expects broker_config as a key within its main config dict.
+        # asdict() already structures it this way.
+        return config
+
+    def validate(self) -> None:
+        """Validates the session configuration."""
+        if not self.broker_config or not isinstance(self.broker_config, dict):
+            raise ValueError("'broker_config' must be a non-empty dictionary.")
+
+        if self.broker_config.get("dev_mode", False):
+            return
+
+        required_keys = [
+            "broker_url",
+            "broker_username",
+            "broker_password",
+            "broker_vpn",
+        ]
+        for key in required_keys:
+            if key not in self.broker_config:
+                raise ValueError(f"'broker_config' is missing required key: {key}")
+
+    @classmethod
+    def from_dict(
+        cls, config: Dict[str, Any], defaults: Optional["SessionConfig"] = None
+    ) -> "SessionConfig":
+        """
+        Creates a SessionConfig instance from a configuration dictionary and defaults.
+        """
+        if defaults:
+            config_dict = asdict(defaults)
+        else:
+            config_dict = {}
+
+        # Deep merge broker_config
+        if "broker_config" in config:
+            merged_broker_config = config_dict.get("broker_config", {}).copy()
+            merged_broker_config.update(config["broker_config"])
+            config_dict["broker_config"] = merged_broker_config
+
+        # Update top-level keys
+        for key, value in config.items():
+            if key != "broker_config":
+                config_dict[key] = value
+
+        # Filter out keys not in SessionConfig to avoid TypeError
+        config_fields = {f.name for f in fields(cls)}
+        filtered_data = {k: v for k, v in config_dict.items() if k in config_fields}
+
+        return cls(**filtered_data)

--- a/src/solace_ai_connector/flow/multi_session_request_response_manager.py
+++ b/src/solace_ai_connector/flow/multi_session_request_response_manager.py
@@ -1,0 +1,156 @@
+"""
+Manages multiple independent request/response sessions for a component.
+"""
+
+import threading
+import weakref
+from typing import Dict, Any, List, Optional
+
+from ..common.log import log
+from ..common.exceptions import SessionLimitExceededError
+from ..common.session_config import SessionConfig
+from .session_registry import SessionRegistry
+from .request_response_session import RequestResponseSession
+
+
+class MultiSessionRequestResponseManager:
+    """
+    Manages multiple independent request/response sessions for a component.
+    """
+
+    def __init__(
+        self,
+        component: Any,
+        default_session_config: Optional[SessionConfig] = None,
+        max_sessions: int = 50,
+    ):
+        """
+        Initializes the MultiSessionRequestResponseManager.
+
+        Args:
+            component: A weak reference to the parent component.
+            default_session_config: The default session configuration.
+            max_sessions: The maximum number of concurrent sessions allowed.
+        """
+        self.component_ref = weakref.ref(component)
+        self.session_registry = SessionRegistry()
+        self.default_session_config = default_session_config
+        self.max_sessions = max_sessions
+        self._lock = threading.RLock()
+        self._shutdown_event = threading.Event()
+
+    def create_session(
+        self, session_config: Optional[Dict[str, Any]] = None
+    ) -> str:
+        """
+        Creates a new request/response session, applies configuration to the default
+        settings, registers it, and returns its unique ID.
+
+        Args:
+            session_config: A dictionary of configuration values for the session.
+
+        Returns:
+            The unique session ID of the newly created session.
+
+        Raises:
+            SessionLimitExceededError: If the maximum number of sessions is reached.
+            RuntimeError: If the parent component reference is lost.
+        """
+        with self._lock:
+            if len(self.session_registry.list_sessions()) >= self.max_sessions:
+                raise SessionLimitExceededError(
+                    "Cannot create new session. Maximum session limit of "
+                    f"{self.max_sessions} reached."
+                )
+
+            session_config = session_config or {}
+
+            # If no default config, the session_config must contain a complete broker_config.
+            if not self.default_session_config:
+                if "broker_config" not in session_config or not isinstance(
+                    session_config.get("broker_config"), dict
+                ):
+                    raise ValueError(
+                        "session_config must contain a 'broker_config' dictionary "
+                        "when no default broker config is defined for the component."
+                    )
+
+            try:
+                final_config = SessionConfig.from_dict(
+                    session_config, self.default_session_config
+                )
+            except (ValueError, TypeError) as e:
+                # Catch potential validation errors from SessionConfig and add context.
+                raise ValueError(
+                    f"Invalid session configuration. The combination of defaults and overrides is incomplete or invalid: {e}"
+                ) from e
+
+            component = self.component_ref()
+            if not component:
+                raise RuntimeError(
+                    "Component reference is lost. Cannot create session."
+                )
+
+            session_id = self.session_registry.generate_session_id()
+            session = RequestResponseSession(
+                session_id=session_id,
+                config=final_config,
+                connector=component.connector,
+            )
+            self.session_registry.register_session(session)
+            log.info(f"Created request/response session: {session_id}")
+            return session_id
+
+    def destroy_session(self, session_id: str) -> bool:
+        """
+        Destroys a session and cleans up its associated resources.
+
+        Args:
+            session_id: The ID of the session to destroy.
+
+        Returns:
+            True if the session was found and destroyed, False otherwise.
+        """
+        session = self.session_registry.unregister_session(session_id)
+        if session:
+            log.info(f"Destroying request/response session: {session_id}")
+            session.cleanup()
+            return True
+        log.warning(f"Attempted to destroy non-existent session: {session_id}")
+        return False
+
+    def get_session(self, session_id: str) -> "RequestResponseSession":
+        """
+        Retrieves an active session by its ID.
+
+        Args:
+            session_id: The ID of the session to retrieve.
+
+        Returns:
+            The RequestResponseSession instance.
+        """
+        return self.session_registry.get_session(session_id)
+
+    def list_sessions(self) -> List[Dict[str, Any]]:
+        """
+        Returns a list of dictionaries containing detailed status for each
+        active session.
+
+        Returns:
+            A list of session status dictionaries.
+        """
+        sessions = self.session_registry.list_sessions()
+        return [session.get_status() for session in sessions]
+
+    def shutdown(self):
+        """
+        Gracefully stops the cleanup thread and destroys all active sessions.
+        """
+        log.info("Shutting down MultiSessionRequestResponseManager.")
+        self._shutdown_event.set()
+
+        all_sessions = self.session_registry.clear()
+        for session in all_sessions:
+            log.info(f"Shutting down session during manager shutdown: {session.session_id}")
+            session.cleanup()
+        log.info("MultiSessionRequestResponseManager shut down complete.")

--- a/src/solace_ai_connector/flow/request_response_session.py
+++ b/src/solace_ai_connector/flow/request_response_session.py
@@ -1,0 +1,120 @@
+"""
+Request/Response Session class for the Solace AI Connector.
+This class wraps a RequestResponseFlowController with session-specific state.
+"""
+
+import time
+import threading
+import uuid
+from typing import Dict, Any, Generator, Tuple
+
+from ..common.session_config import SessionConfig
+from .request_response_flow_controller import RequestResponseFlowController
+from ..common.exceptions import SessionClosedError
+from ..common.message import Message
+
+
+class RequestResponseSession:
+    """
+    Wraps a RequestResponseFlowController with session-specific configuration,
+    managing its lifecycle and state.
+    """
+
+    def __init__(self, session_id: str, config: SessionConfig, connector: Any):
+        """
+        Initializes the RequestResponseSession.
+
+        Args:
+            session_id: The unique identifier for this session.
+            config: The SessionConfig object with all session parameters.
+            connector: A reference to the main SolaceAiConnector instance.
+        """
+        self.session_id = session_id
+        self.config = config
+        self.created_at = time.time()
+        self.last_used_at = time.time()
+        self.active_requests = set()
+        self._lock = threading.RLock()
+        self._is_shutdown = threading.Event()
+
+        # Create the underlying RequestResponseFlowController for this session
+        self.controller = RequestResponseFlowController(
+            config=config.to_controller_config(), connector=connector
+        )
+
+    def do_request_response(
+        self,
+        message: Message,
+        stream: bool = False,
+        streaming_complete_expression: str = None,
+        wait_for_response: bool = True,
+    ) -> Generator[Tuple[Message, bool], None, None]:
+        """
+        Executes a request/response operation using this session's controller.
+
+        Args:
+            message: The request message to send.
+            stream: Whether the response is expected to be streaming.
+            streaming_complete_expression: Expression to detect the end of a stream.
+            wait_for_response: If False, sends the request and returns immediately.
+
+        Yields:
+            A tuple containing the response Message and a boolean indicating if it's the last message.
+
+        Raises:
+            SessionClosedError: If the session has been closed.
+            TimeoutError: If the request times out.
+        """
+        if self._is_shutdown.is_set():
+            raise SessionClosedError(f"Session {self.session_id} has been closed.")
+
+        self.update_last_used()
+        request_id = str(uuid.uuid4())
+
+        with self._lock:
+            self.active_requests.add(request_id)
+
+        try:
+            yield from self.controller.do_broker_request_response(
+                message, stream, streaming_complete_expression, wait_for_response
+            )
+        finally:
+            with self._lock:
+                self.active_requests.remove(request_id)
+
+    def get_status(self) -> Dict[str, Any]:
+        """
+        Returns a dictionary with detailed status information for this session.
+
+        Returns:
+            A dictionary containing session status.
+        """
+        with self._lock:
+            active_request_count = len(self.active_requests)
+
+        return {
+            "session_id": self.session_id,
+            "created_at": self.created_at,
+            "last_used_at": self.last_used_at,
+            "active_request_count": active_request_count,
+        }
+
+    def cleanup(self) -> None:
+        """
+        Cleans up all resources used by the session, including the underlying
+        flow controller and its broker connection.
+        """
+        if self._is_shutdown.is_set():
+            return
+
+        self._is_shutdown.set()
+        if hasattr(self.controller, "cleanup"):
+            self.controller.cleanup()
+        elif self.controller and self.controller.flow:
+            # Fallback if cleanup() is not yet on the controller.
+            # The controller's internal flow cleanup will handle resources.
+            self.controller.flow.cleanup()
+
+    def update_last_used(self) -> None:
+        """Updates the last used timestamp for the session."""
+        self.last_used_at = time.time()

--- a/src/solace_ai_connector/flow/session_registry.py
+++ b/src/solace_ai_connector/flow/session_registry.py
@@ -1,0 +1,99 @@
+"""Thread-safe registry for managing request/response sessions."""
+
+import threading
+from typing import Dict, List, TYPE_CHECKING
+
+from ..common.exceptions import SessionNotFoundError
+
+if TYPE_CHECKING:
+    from .request_response_session import RequestResponseSession
+
+
+class SessionRegistry:
+    """
+    Thread-safe registry for tracking active request/response sessions.
+    """
+
+    def __init__(self):
+        """Initializes the SessionRegistry."""
+        self._sessions: Dict[str, "RequestResponseSession"] = {}
+        self._lock = threading.RLock()
+        self._session_counter = 0
+
+    def generate_session_id(self) -> str:
+        """
+        Generates a unique, thread-safe session ID.
+
+        Returns:
+            A unique session ID string.
+        """
+        with self._lock:
+            self._session_counter += 1
+            return f"session_{self._session_counter}"
+
+    def register_session(self, session: "RequestResponseSession") -> None:
+        """
+        Adds a session to the registry.
+
+        Args:
+            session: The RequestResponseSession instance to register.
+        """
+        with self._lock:
+            if session.session_id in self._sessions:
+                raise ValueError(f"Session ID {session.session_id} already exists.")
+            self._sessions[session.session_id] = session
+
+    def unregister_session(self, session_id: str) -> "RequestResponseSession":
+        """
+        Removes and returns a session from the registry.
+
+        Args:
+            session_id: The ID of the session to unregister.
+
+        Returns:
+            The removed RequestResponseSession instance, or None if not found.
+        """
+        with self._lock:
+            return self._sessions.pop(session_id, None)
+
+    def get_session(self, session_id: str) -> "RequestResponseSession":
+        """
+        Retrieves a session by its ID.
+
+        Args:
+            session_id: The ID of the session to retrieve.
+
+        Returns:
+            The RequestResponseSession instance.
+
+        Raises:
+            SessionNotFoundError: If the session ID is not found.
+        """
+        with self._lock:
+            session = self._sessions.get(session_id)
+            if not session:
+                raise SessionNotFoundError(f"Session with ID '{session_id}' not found.")
+            return session
+
+    def list_sessions(self) -> List["RequestResponseSession"]:
+        """
+        Returns a list of all active session objects.
+
+        Returns:
+            A list of RequestResponseSession instances.
+        """
+        with self._lock:
+            return list(self._sessions.values())
+
+    def clear(self) -> List["RequestResponseSession"]:
+        """
+        Removes all sessions from the registry and returns them.
+        Used for graceful shutdown.
+
+        Returns:
+            A list of all RequestResponseSession instances that were removed.
+        """
+        with self._lock:
+            all_sessions = list(self._sessions.values())
+            self._sessions.clear()
+            return all_sessions

--- a/tests/test_multi_session_request_response.py
+++ b/tests/test_multi_session_request_response.py
@@ -1,0 +1,526 @@
+import sys
+import pytest
+
+sys.path.append("src")
+
+from solace_ai_connector.common.message import Message
+from solace_ai_connector.test_utils.utils_for_test_files import (
+    create_test_flows,
+    dispose_connector,
+)
+from solace_ai_connector.common.exceptions import (
+    SessionNotFoundError,
+    SessionLimitExceededError,
+)
+from solace_ai_connector.components.inputs_outputs.broker_request_response import (
+    BrokerRequestResponse,
+    DEFAULT_REPLY_METADATA_KEY,
+    DEFAULT_REPLY_TOPIC_KEY,
+)
+
+
+def test_multi_session_lifecycle_and_isolation():
+    """
+    Tests the basic lifecycle of multi-session request/response:
+    - Session creation
+    - Independent usage
+    - Listing active sessions
+    - Session destruction
+    - Error on using a destroyed session
+    """
+    config = {
+        "flows": [
+            {
+                "name": "test_multi_session_flow",
+                "components": [
+                    {
+                        "component_name": "session_handler",
+                        "component_module": "handler_callback",
+                        "multi_session_request_response": {
+                            "enabled": True,
+                            "default_broker_config": {
+                                "broker_type": "test",
+                                "broker_url": "test",
+                                "broker_username": "test",
+                                "broker_password": "test",
+                                "broker_vpn": "test",
+                            },
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+
+    connector, flows = create_test_flows(config)
+    # Get the component instance directly to call its API
+    component = flows[0]["flow"].component_groups[0][0]
+
+    try:
+        # 1. Create two sessions
+        session_id_A = component.create_request_response_session()
+        session_id_B = component.create_request_response_session(
+            session_config={
+                "request_expiry_ms": 60000
+            }  # Custom config for this session
+        )
+        assert session_id_A != session_id_B
+
+        # 2. Use both sessions independently
+        message_A = Message(payload={"data": "A"})
+        response_A = component.do_broker_request_response(
+            message_A, session_id=session_id_A
+        )
+        assert response_A.get_payload() == {"data": "A"}
+
+        message_B = Message(payload={"data": "B"})
+        response_B = component.do_broker_request_response(
+            message_B, session_id=session_id_B
+        )
+        assert response_B.get_payload() == {"data": "B"}
+
+        # 3. List sessions and verify status
+        sessions = component.list_request_response_sessions()
+        assert len(sessions) == 2
+        session_ids_from_list = {s["session_id"] for s in sessions}
+        assert session_ids_from_list == {session_id_A, session_id_B}
+        for s in sessions:
+            assert s["active_request_count"] == 0
+
+        # 4. Destroy one session
+        assert component.destroy_request_response_session(session_id_A) is True
+        sessions_after_destroy = component.list_request_response_sessions()
+        assert len(sessions_after_destroy) == 1
+        assert sessions_after_destroy[0]["session_id"] == session_id_B
+
+        # 5. Verify error on using destroyed session
+        with pytest.raises(SessionNotFoundError):
+            component.do_broker_request_response(message_A, session_id=session_id_A)
+
+        # 6. Verify the other session is still functional
+        response_B_again = component.do_broker_request_response(
+            message_B, session_id=session_id_B
+        )
+        assert response_B_again.get_payload() == {"data": "B"}
+        # Also verify that the internal user properties were cleaned up
+        user_props = response_B_again.get_user_properties()
+        assert DEFAULT_REPLY_METADATA_KEY not in user_props
+        assert DEFAULT_REPLY_TOPIC_KEY not in user_props
+
+        # 7. Destroy the second session
+        assert component.destroy_request_response_session(session_id_B) is True
+        assert len(component.list_request_response_sessions()) == 0
+
+    finally:
+        dispose_connector(connector)
+
+
+def test_fire_and_forget_sends_message():
+    """
+    Tests that do_broker_request_response with wait_for_response=False
+    correctly sends the message (fire-and-forget).
+    """
+    config = {
+        "flows": [
+            {
+                "name": "test_fire_and_forget_flow",
+                "components": [
+                    {
+                        "component_name": "session_handler",
+                        "component_module": "handler_callback",
+                        "multi_session_request_response": {
+                            "enabled": True,
+                            "default_broker_config": {
+                                "broker_type": "test",
+                                "broker_url": "test",
+                                "broker_username": "test",
+                                "broker_password": "test",
+                                "broker_vpn": "test",
+                            },
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+
+    connector, flows = create_test_flows(config)
+    component = flows[0]["flow"].component_groups[0][0]
+
+    try:
+        # 1. Create a session
+        session_id = component.create_request_response_session()
+
+        # 2. Spy on the send_message method of the controller
+        with unittest.mock.patch(
+            "solace_ai_connector.flow.request_response_flow_controller.RequestResponseFlowController.send_message"
+        ) as mock_send:
+            # 3. Call fire-and-forget
+            ff_message = Message(payload={"data": "fire_and_forget_sync"})
+            response = component.do_broker_request_response(
+                ff_message, session_id=session_id, wait_for_response=False
+            )
+
+            # 4. Assert that the call returned None and send_message was called
+            assert response is None
+            mock_send.assert_called_once()
+
+        # 5. Destroy the session
+        component.destroy_request_response_session(session_id)
+
+    finally:
+        dispose_connector(connector)
+
+
+@pytest.mark.asyncio
+async def test_async_multi_session_lifecycle():
+    """
+    Tests the async version of do_broker_request_response with the multi-session manager.
+    """
+    config = {
+        "flows": [
+            {
+                "name": "test_async_multi_session_flow",
+                "components": [
+                    {
+                        "component_name": "session_handler",
+                        "component_module": "handler_callback",
+                        "multi_session_request_response": {
+                            "enabled": True,
+                            "default_broker_config": {
+                                "broker_type": "test",
+                                "broker_url": "test",
+                                "broker_username": "test",
+                                "broker_password": "test",
+                                "broker_vpn": "test",
+                            },
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+
+    connector, flows = create_test_flows(config)
+    component = flows[0]["flow"].component_groups[0][0]
+
+    try:
+        # 1. Create a session
+        session_id = component.create_request_response_session()
+        assert session_id is not None
+
+        # 2. Use the session with the async method (blocking wait)
+        message = Message(payload={"data": "async_test"})
+        response = await component.do_broker_request_response_async(
+            message, session_id=session_id
+        )
+        assert response.get_payload() == {"data": "async_test"}
+
+        # 3. Test fire-and-forget async
+        ff_message = Message(payload={"data": "fire_and_forget"})
+        ff_response = await component.do_broker_request_response_async(
+            ff_message, session_id=session_id, wait_for_response=False
+        )
+        assert ff_response is None
+
+        # 4. Destroy the session
+        assert component.destroy_request_response_session(session_id) is True
+
+        # 5. Verify error on using destroyed session with async method
+        with pytest.raises(SessionNotFoundError):
+            await component.do_broker_request_response_async(
+                message, session_id=session_id
+            )
+
+    finally:
+        dispose_connector(connector)
+
+
+@pytest.mark.asyncio
+async def test_async_multi_session_streaming():
+    """
+    Tests the async version of do_broker_request_response with streaming.
+    """
+    config = {
+        "flows": [
+            {
+                "name": "test_async_streaming_flow",
+                "components": [
+                    {
+                        "component_name": "session_handler",
+                        "component_module": "handler_callback",
+                        "multi_session_request_response": {
+                            "enabled": True,
+                            "default_broker_config": {
+                                "broker_type": "test_streaming",
+                                "broker_url": "test",
+                                "broker_username": "test",
+                                "broker_password": "test",
+                                "broker_vpn": "test",
+                            },
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+
+    connector, flows = create_test_flows(config)
+    component = flows[0]["flow"].component_groups[0][0]
+
+    try:
+        session_id = component.create_request_response_session()
+
+        request_payload = [
+            {"text": "chunk1", "done": False},
+            {"text": "chunk2", "done": False},
+            {"text": "chunk3", "done": True},
+        ]
+        message = Message(payload=request_payload, topic="test/stream")
+
+        response_generator = await component.do_broker_request_response_async(
+            message,
+            session_id=session_id,
+            stream=True,
+            streaming_complete_expression="input.payload:done",
+        )
+
+        results = []
+        for chunk, is_last in response_generator:
+            results.append(chunk.get_payload())
+            if is_last:
+                break
+
+        assert len(results) == 3
+        assert results[0]["text"] == "chunk1"
+        assert results[2]["text"] == "chunk3"
+        assert results[2]["done"] is True
+
+        component.destroy_request_response_session(session_id)
+
+    finally:
+        dispose_connector(connector)
+
+
+def test_multi_session_no_default_config():
+    """
+    Tests that multi-session mode works without a default broker config.
+    - Fails to create a session without overrides.
+    - Succeeds in creating a session with full overrides.
+    - The created session is functional.
+    """
+    config = {
+        "flows": [
+            {
+                "name": "test_no_default_flow",
+                "components": [
+                    {
+                        "component_name": "session_handler",
+                        "component_module": "handler_callback",
+                        "multi_session_request_response": {
+                            "enabled": True
+                            # NO default_broker_config here
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+
+    connector, flows = create_test_flows(config)
+    component = flows[0]["flow"].component_groups[0][0]
+
+    try:
+        # 1. Verify creating a session with NO overrides fails
+        with pytest.raises(
+            ValueError, match="must contain a 'broker_config' dictionary"
+        ):
+            component.create_request_response_session()
+
+        # 2. Create a session WITH a full broker_config override
+        session_id = component.create_request_response_session(
+            session_config={
+                "broker_config": {
+                    "broker_type": "test",
+                    "broker_url": "test",
+                    "broker_username": "test",
+                    "broker_password": "test",
+                    "broker_vpn": "test",
+                }
+            }
+        )
+        assert session_id is not None
+        assert len(component.list_request_response_sessions()) == 1
+
+        # 3. Verify the session is functional
+        message = Message(payload={"data": "no_default_test"})
+        response = component.do_broker_request_response(message, session_id=session_id)
+        assert response.get_payload() == {"data": "no_default_test"}
+
+        # 4. Destroy the session
+        assert component.destroy_request_response_session(session_id) is True
+        assert len(component.list_request_response_sessions()) == 0
+
+    finally:
+        dispose_connector(connector)
+
+
+def test_max_sessions_limit():
+    """Tests that the max_sessions limit is enforced."""
+    config = {
+        "flows": [
+            {
+                "name": "test_max_sessions_flow",
+                "components": [
+                    {
+                        "component_name": "session_handler",
+                        "component_module": "handler_callback",
+                        "multi_session_request_response": {
+                            "enabled": True,
+                            "max_sessions": 2,  # Set a low limit
+                            "default_broker_config": {
+                                "broker_type": "test",
+                                "broker_url": "test",
+                                "broker_username": "test",
+                                "broker_password": "test",
+                                "broker_vpn": "test",
+                            },
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+
+    connector, flows = create_test_flows(config)
+    component = flows[0]["flow"].component_groups[0][0]
+
+    try:
+        # 1. Create sessions up to the limit
+        session_id_1 = component.create_request_response_session()
+        component.create_request_response_session()
+        assert len(component.list_request_response_sessions()) == 2
+
+        # 2. Verify that creating one more session raises an error
+        with pytest.raises(SessionLimitExceededError):
+            component.create_request_response_session()
+
+        # 3. Destroy a session and verify a new one can be created
+        component.destroy_request_response_session(session_id_1)
+        assert len(component.list_request_response_sessions()) == 1
+        component.create_request_response_session()
+        assert len(component.list_request_response_sessions()) == 2
+
+    finally:
+        dispose_connector(connector)
+
+
+import unittest.mock
+
+
+def test_backward_compatibility_with_legacy_rrc():
+    """
+    Tests that do_broker_request_response works correctly with the legacy,
+    component-level RRC configuration when no session_id is provided.
+    """
+    config = {
+        "flows": [
+            {
+                "name": "test_legacy_flow",
+                "components": [
+                    {
+                        "component_name": "legacy_requester",
+                        "component_module": "handler_callback",
+                        # NOTE: No multi_session_request_response block
+                        "broker_request_response": {
+                            "enabled": True,
+                            "broker_config": {
+                                "broker_type": "test",
+                                "broker_url": "test",
+                                "broker_username": "test",
+                                "broker_password": "test",
+                                "broker_vpn": "test",
+                            },
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+
+    connector, flows = create_test_flows(config)
+    component = flows[0]["flow"].component_groups[0][0]
+
+    try:
+        # Call do_broker_request_response WITHOUT a session_id
+        message = Message(payload={"data": "legacy_test"})
+        response = component.do_broker_request_response(message)
+
+        # Verify the response is correct, proving the fallback worked
+        assert response.get_payload() == {"data": "legacy_test"}
+
+    finally:
+        dispose_connector(connector)
+
+
+def test_rrc_process_response_with_decode_error():
+    """
+    Unit tests the process_response method of BrokerRequestResponse
+    to ensure it handles payload decode errors correctly.
+    """
+    # 1. Create an instance of the component to test, mocking dependencies
+    with (
+        unittest.mock.patch(
+            "solace_ai_connector.components.inputs_outputs.broker_request_response.BrokerRequestResponse.connect"
+        ),
+        unittest.mock.patch(
+            "solace_ai_connector.components.inputs_outputs.broker_request_response.BrokerRequestResponse.start"
+        ),
+    ):
+        rrc = BrokerRequestResponse(
+            config={
+                "component_config": {
+                    "payload_format": "json",
+                    "user_properties_reply_metadata_key": "test_meta_key",
+                    "user_properties_reply_topic_key": "test_topic_key",
+                    # Add dummy broker config to pass validation
+                    "broker_url": "dummy_url",
+                    "broker_username": "dummy_user",
+                    "broker_password": "dummy_password",
+                    "broker_vpn": "dummy_vpn",
+                }
+            },
+            cache_service=unittest.mock.MagicMock(),
+        )
+
+    # 2. Mock dependencies needed by process_response
+    rrc.test_mode = True
+    rrc.process_post_invoke = unittest.mock.MagicMock()
+    rrc.cache_service.get_data.return_value = {
+        "request_id": "123",
+        "stream": False,
+    }
+
+    # 3. Create a fake response message with a bad payload
+    bad_payload = '{"invalid": json}'  # Invalid JSON string
+    user_props = {"test_meta_key": '[{"request_id": "123"}]'}
+    mock_broker_message = Message(payload=bad_payload, user_properties=user_props)
+
+    # 4. Call the method under test
+    rrc.process_response(mock_broker_message)
+
+    # 5. Assert that process_post_invoke was called with the error payload
+    rrc.process_post_invoke.assert_called_once()
+    call_args = rrc.process_post_invoke.call_args
+    response_data = call_args[0][0]  # First positional argument (the 'result' dict)
+    message_arg = call_args[0][1]  # Second positional argument (the 'message' object)
+
+    # The payload of the new message should be the error dict
+    assert isinstance(message_arg.get_payload(), dict)
+    assert message_arg.get_payload()["error"] == "Payload decode error"
+    assert "details" in message_arg.get_payload()
+    assert "Invalid JSON payload" in message_arg.get_payload()["details"]
+
+    # The 'result' passed to process_post_invoke should also contain the error payload
+    assert isinstance(response_data["payload"], dict)
+    assert response_data["payload"]["error"] == "Payload decode error"

--- a/tests/unit/test_simplified_app.py
+++ b/tests/unit/test_simplified_app.py
@@ -266,7 +266,11 @@ def test_flow_create_component_group_with_class():
     mock_flow.connector.timer_manager = MagicMock()
     mock_flow.connector.cache_service = MagicMock()
     mock_flow.cache_service = MagicMock()  # Add missing cache_service attribute
-    mock_flow.app = MagicMock()
+    mock_flow.app = MagicMock(spec=App)
+    # Configure the mock app's get_config to return None, mimicking real behavior
+    # when a config key is not found. This prevents it from returning another MagicMock.
+    mock_flow.app.get_config.return_value = None
+    mock_flow.app.app_info = {}  # Add app_info attribute to the mock
     mock_flow.name = "test_flow"
     mock_flow.instance_name = "test_instance"
     mock_flow.put_errors_in_error_queue = True
@@ -455,6 +459,7 @@ def mock_component_for_get_config():
     mock_app.get_config = MagicMock(
         side_effect=lambda key, default=None: app_level_config.get(key, default)
     )
+    mock_app.app_info = {}  # Add app_info attribute to the mock
 
     # Mock ComponentBase instance
     mock_component = MagicMock(spec=ComponentBase)


### PR DESCRIPTION
## Pull Request Overview

This PR implements multi-session request-response functionality for the Solace AI Connector, allowing components to create and manage multiple independent request/response sessions with different broker configurations.

Additionally, there are some log improvements to better allow configuration of logging

- Adds a new multi-session manager system that enables components to dynamically create, use, and destroy independent request/response sessions
- Extends the existing ComponentBase API with session management methods while maintaining backward compatibility
- Includes comprehensive error handling for session lifecycle management and proper resource cleanup


