### PR TITLE
fix(DATGO-128301):- Make observability framework defensive and fail-safe

### DIFF
--- a/src/solace_ai_connector/common/observability/recorders/__init__.py
+++ b/src/solace_ai_connector/common/observability/recorders/__init__.py
@@ -1,8 +1,15 @@
 """Recorder classes for OpenTelemetry instruments."""
 
-from .base import MetricRecorder, NoOpRecorder
+from .base import MetricRecorder, NoOpRecorder, NoOpObservableGauge
 from .histogram import HistogramRecorder
 from .counter import CounterRecorder
 from .gauge import GaugeRecorder
 
-__all__ = ["MetricRecorder", "NoOpRecorder", "HistogramRecorder", "CounterRecorder", "GaugeRecorder"]
+__all__ = [
+    "MetricRecorder",
+    "NoOpRecorder",
+    "NoOpObservableGauge",
+    "HistogramRecorder",
+    "CounterRecorder",
+    "GaugeRecorder"
+]

--- a/src/solace_ai_connector/common/observability/recorders/base.py
+++ b/src/solace_ai_connector/common/observability/recorders/base.py
@@ -28,4 +28,7 @@ class NoOpObservableGauge:
     Mimics OpenTelemetry ObservableGauge interface but does nothing.
     Allows consistent Null Object pattern across all metric creation methods.
     """
-    pass  # Observable gauges are callback-based - no methods to implement
+
+    def close(self):
+        """Unregister callbacks (no-op when observability disabled)."""
+        pass

--- a/src/solace_ai_connector/common/observability/recorders/base.py
+++ b/src/solace_ai_connector/common/observability/recorders/base.py
@@ -19,3 +19,13 @@ class NoOpRecorder(MetricRecorder):
     def record(self, value: Any, labels: Dict[str, str]):
         """Record a metric value with labels (no-op)."""
         pass
+
+
+class NoOpObservableGauge:
+    """
+    Silent no-op observable gauge returned when observability is disabled.
+
+    Mimics OpenTelemetry ObservableGauge interface but does nothing.
+    Allows consistent Null Object pattern across all metric creation methods.
+    """
+    pass  # Observable gauges are callback-based - no methods to implement

--- a/src/solace_ai_connector/common/observability/registry.py
+++ b/src/solace_ai_connector/common/observability/registry.py
@@ -2,6 +2,7 @@
 
 from typing import Optional, Dict, List, Callable
 import logging
+import threading
 from opentelemetry import metrics
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.view import View, ExplicitBucketHistogramAggregation
@@ -18,17 +19,17 @@ logger = logging.getLogger(__name__)
 class MetricRegistry:
     """
     Singleton registry for metrics collection.
+    Thread-safe singleton with defensive auto-initialization.
     """
-
     _instance: Optional['MetricRegistry'] = None
+    _lock = threading.Lock()
 
     def __init__(self, config: dict):
         """
-        Private constructor - do not call directly.
-
         Use MetricRegistry.initialize(config) for explicit initialization.
         Use MetricRegistry.get_instance() to retrieve singleton.
         """
+        self._explicitly_initialized = False
         # Load observability config
         self.obs_config = load_observability_config(config)
 
@@ -67,36 +68,43 @@ class MetricRegistry:
     def initialize(cls, config: dict) -> 'MetricRegistry':
         """
         Initialize MetricRegistry singleton with configuration.
-
         Call this once at application startup.
-
         Args:
             config: Full application configuration dict
-
         Returns:
             MetricRegistry singleton instance
-
         Raises:
-            RuntimeError: If already initialized with different config
+            RuntimeError: If already explicitly initialized with different config
+        Note:
+            Thread-safe singleton initialization.
+            Will override auto-initialized instances (from get_instance()).
+            This ensures explicit initialization always wins regardless of call order.
         """
-        if cls._instance is not None:
-            # In tests, allow re-initialization if config is identical (idempotent)
-            # Otherwise, require explicit reset first to prevent conflicting configs
-            existing_config = cls._instance.obs_config
-            new_config = load_observability_config(config)
+        with cls._lock:
+            if cls._instance is not None:
+                # Allow override if instance was auto-initialized (not explicit)
+                if not cls._instance._explicitly_initialized:
+                    logger.debug("Overriding auto-initialized instance with explicit config")
+                    cls._instance = cls(config)
+                    cls._instance._explicitly_initialized = True
+                    return cls._instance
 
-            if existing_config == new_config:
-                # Idempotent initialization - return existing instance
-                logger.debug("MetricRegistry already initialized with same config")
-                return cls._instance
-            else:
-                raise RuntimeError(
-                    "MetricRegistry already initialized with different config. "
-                    "Call MetricRegistry.reset() first."
-                )
+                # Instance was explicitly initialized - check for config conflicts
+                existing_config = cls._instance.obs_config
+                new_config = load_observability_config(config)
 
-        cls._instance = cls(config)
-        return cls._instance
+                if existing_config == new_config:
+                    # Idempotent initialization - return existing instance
+                    logger.debug("MetricRegistry already initialized with same config")
+                    return cls._instance
+                else:
+                    raise RuntimeError(
+                        "MetricRegistry already initialized with different config. "
+                        "Call MetricRegistry.reset() first."
+                    )
+            cls._instance = cls(config)
+            cls._instance._explicitly_initialized = True
+            return cls._instance
 
     @classmethod
     def get_instance(cls) -> 'MetricRegistry':
@@ -111,17 +119,22 @@ class MetricRegistry:
 
         Note:
             NEVER raises - always returns a valid instance.
+            Auto-initialized instances can be overridden by subsequent initialize() calls.
             For explicit initialization, use MetricRegistry.initialize(config) instead.
         """
         if cls._instance is None:
-            logger.debug("MetricRegistry not initialized - auto-initializing with observability disabled")
-            cls._instance = cls({})  # Empty config = disabled observability
+            with cls._lock:
+                if cls._instance is None:
+                    logger.debug("MetricRegistry not initialized - auto-initializing with observability disabled")
+                    cls._instance = cls({})  # Empty config = disabled observability
+                    cls._instance._explicitly_initialized = False  # Mark as auto-initialized
         return cls._instance
 
     @classmethod
     def reset(cls):
         """Reset singleton (for testing)."""
-        cls._instance = None
+        with cls._lock:
+            cls._instance = None
 
     def _prepare_metric_configs(self) -> Dict:
         """Merge user config with defaults for distribution metrics (histograms)."""

--- a/src/solace_ai_connector/common/observability/registry.py
+++ b/src/solace_ai_connector/common/observability/registry.py
@@ -11,7 +11,7 @@ from opentelemetry.metrics import Observation
 from prometheus_client import generate_latest, REGISTRY
 
 from .config import DEFAULT_DISTRIBUTION_METRICS, DEFAULT_VALUE_METRICS, load_observability_config, validate_config
-from .recorders import MetricRecorder, NoOpRecorder, HistogramRecorder, CounterRecorder, GaugeRecorder
+from .recorders import MetricRecorder, NoOpRecorder, NoOpObservableGauge, HistogramRecorder, CounterRecorder, GaugeRecorder
 
 logger = logging.getLogger(__name__)
 
@@ -23,23 +23,12 @@ class MetricRegistry:
     _instance: Optional['MetricRegistry'] = None
 
     def __init__(self, config: dict):
-        """Initialize registry with configuration."""
-        if MetricRegistry._instance is not None:
-            # In tests, allow re-initialization if config is identical (idempotent)
-            # Otherwise, require explicit reset first to prevent conflicting configs
-            existing_config = MetricRegistry._instance.obs_config
-            new_config = load_observability_config(config)
+        """
+        Private constructor - do not call directly.
 
-            if existing_config == new_config:
-                # Idempotent initialization - return existing instance
-                logger.debug("MetricRegistry already initialized with same config")
-                return
-            else:
-                raise RuntimeError(
-                    "MetricRegistry already initialized with different config. "
-                    "Call MetricRegistry.reset() first."
-                )
-
+        Use MetricRegistry.initialize(config) for explicit initialization.
+        Use MetricRegistry.get_instance() to retrieve singleton.
+        """
         # Load observability config
         self.obs_config = load_observability_config(config)
 
@@ -49,7 +38,6 @@ class MetricRegistry:
             logger.info("Observability disabled in configuration")
             self.duration_recorders = {}  # Histogram recorders
             self._value_recorders = {}    # Counter/gauge recorders
-            MetricRegistry._instance = self
             return
 
         # Validate configuration
@@ -69,7 +57,6 @@ class MetricRegistry:
         # Initialize OpenTelemetry (creates Views + MeterProvider + Histograms + Counters)
         self._initialize_otel_and_recorders()
 
-        MetricRegistry._instance = self
         logger.info(
             "MetricRegistry initialized with %s duration recorders and %s value recorders",
             len(self.duration_recorders),
@@ -77,10 +64,58 @@ class MetricRegistry:
         )
 
     @classmethod
+    def initialize(cls, config: dict) -> 'MetricRegistry':
+        """
+        Initialize MetricRegistry singleton with configuration.
+
+        Call this once at application startup.
+
+        Args:
+            config: Full application configuration dict
+
+        Returns:
+            MetricRegistry singleton instance
+
+        Raises:
+            RuntimeError: If already initialized with different config
+        """
+        if cls._instance is not None:
+            # In tests, allow re-initialization if config is identical (idempotent)
+            # Otherwise, require explicit reset first to prevent conflicting configs
+            existing_config = cls._instance.obs_config
+            new_config = load_observability_config(config)
+
+            if existing_config == new_config:
+                # Idempotent initialization - return existing instance
+                logger.debug("MetricRegistry already initialized with same config")
+                return cls._instance
+            else:
+                raise RuntimeError(
+                    "MetricRegistry already initialized with different config. "
+                    "Call MetricRegistry.reset() first."
+                )
+
+        cls._instance = cls(config)
+        return cls._instance
+
+    @classmethod
     def get_instance(cls) -> 'MetricRegistry':
-        """Get singleton instance."""
+        """
+        Get MetricRegistry singleton instance.
+
+        Auto-initializes with observability disabled if not already initialized.
+        This ensures instrumented code never fails even when observability not configured.
+
+        Returns:
+            MetricRegistry instance (initialized or auto-created no-op instance)
+
+        Note:
+            NEVER raises - always returns a valid instance.
+            For explicit initialization, use MetricRegistry.initialize(config) instead.
+        """
         if cls._instance is None:
-            raise RuntimeError("MetricRegistry not initialized")
+            logger.debug("MetricRegistry not initialized - auto-initializing with observability disabled")
+            cls._instance = cls({})  # Empty config = disabled observability
         return cls._instance
 
     @classmethod
@@ -343,10 +378,14 @@ class MetricRegistry:
             unit: Metric unit (default: "1" for dimensionless)
 
         Returns:
-            ObservableGauge instrument, or None if disabled
+            ObservableGauge instrument (or NoOpObservableGauge if disabled)
+
+        Note:
+            Consistent with create_counter/create_gauge - always returns an object,
+            never None. Uses Null Object pattern for disabled state.
         """
         if not self.enabled:
-            return None
+            return NoOpObservableGauge()
 
         full_name = self._get_full_metric_name(name)
         excluded = self._get_value_metric_excluded_labels(name)

--- a/src/solace_ai_connector/solace_ai_connector.py
+++ b/src/solace_ai_connector/solace_ai_connector.py
@@ -55,7 +55,7 @@ class SolaceAiConnector:
         # Initialize observability EARLY (before apps)
         # This ensures MetricRegistry is ready before any instrumented code runs
         try:
-            self.metric_registry = MetricRegistry(config)
+            self.metric_registry = MetricRegistry.initialize(config)
         except Exception as e:
             logger.error("Failed to initialize observability: %s", e)
             raise InitializationError("Observability initialization failed") from e

--- a/tests/common/test_observability.py
+++ b/tests/common/test_observability.py
@@ -73,7 +73,7 @@ class TestConfigurationLoading:
     def test_registry_initialization_disabled(self):
         """Test MetricRegistry initialization when disabled."""
         config = {}
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         assert registry.enabled is False
         assert registry.duration_recorders == {}
@@ -89,7 +89,7 @@ class TestConfigurationLoading:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         assert registry.enabled is True
         assert registry.metric_prefix == 'sam'
@@ -132,7 +132,7 @@ class TestDefaultSystemMetrics:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         # Verify all 7 default metrics exist
         expected_metrics = [
@@ -159,7 +159,7 @@ class TestDefaultSystemMetrics:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         # Verify default buckets for each metric
         for metric_name, default_config in DEFAULT_DISTRIBUTION_METRICS.items():
@@ -176,7 +176,7 @@ class TestDefaultSystemMetrics:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         # gen_ai.client.operation.duration should exclude 'tokens' by default
         genai_recorder = registry.duration_recorders['gen_ai.client.operation.duration']
@@ -193,7 +193,7 @@ class TestDefaultSystemMetrics:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         # Verify prefix is applied
         full_name = registry._get_full_metric_name('outbound.request.duration')
@@ -209,7 +209,7 @@ class TestDefaultSystemMetrics:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         full_name = registry._get_full_metric_name('outbound.request.duration')
         assert full_name == 'outbound.request.duration'
@@ -233,7 +233,7 @@ class TestDistributedMetricsOverride:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         # Verify custom buckets are applied
         genai_recorder = registry.duration_recorders['gen_ai.client.operation.duration']
@@ -255,7 +255,7 @@ class TestDistributedMetricsOverride:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         # Verify custom exclude_labels are applied
         db_recorder = registry.duration_recorders['db.duration']
@@ -277,7 +277,7 @@ class TestDistributedMetricsOverride:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         # Get the recorder and verify it filters labels
         db_recorder = registry.duration_recorders['db.duration']
@@ -318,7 +318,7 @@ class TestDistributedMetricsOverride:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         # Verify metric was not created
         assert 'gateway.ttfb.duration' not in registry.duration_recorders
@@ -344,7 +344,7 @@ class TestDistributedMetricsOverride:
                 'observability': obs_config
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         # Custom metric should be created
         assert 'my.custom.metric' in registry.duration_recorders
@@ -452,7 +452,7 @@ class TestCustomMetricsFactoryMethods:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         counter = registry.create_counter(
             name='test.events.count',
@@ -465,7 +465,7 @@ class TestCustomMetricsFactoryMethods:
     def test_create_counter_when_disabled(self):
         """Test create_counter returns NoOpRecorder when disabled."""
         config = {}
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         counter = registry.create_counter(
             name='test.events.count',
@@ -484,7 +484,7 @@ class TestCustomMetricsFactoryMethods:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         gauge = registry.create_gauge(
             name='test.queue.depth',
@@ -497,7 +497,7 @@ class TestCustomMetricsFactoryMethods:
     def test_create_gauge_when_disabled(self):
         """Test create_gauge returns NoOpRecorder when disabled."""
         config = {}
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         gauge = registry.create_gauge(
             name='test.queue.depth',
@@ -516,7 +516,7 @@ class TestCustomMetricsFactoryMethods:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         def callback(options):
             from opentelemetry.metrics import Observation
@@ -531,9 +531,9 @@ class TestCustomMetricsFactoryMethods:
         assert obs_gauge is not None  # Returns OTel instrument
 
     def test_create_observable_gauge_when_disabled(self):
-        """Test create_observable_gauge returns None when disabled."""
+        """Test create_observable_gauge returns NoOpObservableGauge when disabled."""
         config = {}
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         def callback(options):
             from opentelemetry.metrics import Observation
@@ -545,7 +545,9 @@ class TestCustomMetricsFactoryMethods:
             description='Test observable gauge'
         )
 
-        assert obs_gauge is None
+        # Returns no-op object (not None) for consistency with create_counter/create_gauge
+        from solace_ai_connector.common.observability.recorders import NoOpObservableGauge
+        assert isinstance(obs_gauge, NoOpObservableGauge)
 
     def test_custom_counter_label_filtering(self):
         """Test custom: config filters labels for counters."""
@@ -562,7 +564,7 @@ class TestCustomMetricsFactoryMethods:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         counter = registry.create_counter(
             name='gateway.events.processed',
@@ -588,7 +590,7 @@ class TestCustomMetricsFactoryMethods:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         gauge = registry.create_gauge(
             name='broker.active.connections',
@@ -614,7 +616,7 @@ class TestCustomMetricsFactoryMethods:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         counter = registry.create_counter(
             name='gateway.events.processed',
@@ -654,7 +656,7 @@ class TestCustomMetricsFactoryMethods:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         gauge = registry.create_gauge(
             name='broker.active.connections',
@@ -702,7 +704,7 @@ class TestCustomMetricsFactoryMethods:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         gauge = registry.create_gauge(
             name='broker.active.connections',
@@ -743,7 +745,7 @@ class TestCustomMetricsFactoryMethods:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         gauge = registry.create_gauge(
             name='queue.depth',
@@ -796,7 +798,7 @@ class TestCustomMetricsFactoryMethods:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         from opentelemetry.metrics import Observation
 
@@ -895,7 +897,7 @@ class TestCustomMetricsFactoryMethods:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         # The full name should have prefix applied
         full_name = registry._get_full_metric_name('custom.metric')
@@ -915,7 +917,7 @@ class TestGetRecorder:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         recorder = registry.get_recorder('db.duration')
         assert isinstance(recorder, HistogramRecorder)
@@ -923,7 +925,7 @@ class TestGetRecorder:
     def test_get_recorder_returns_none_when_disabled(self):
         """Test get_recorder returns None when disabled."""
         config = {}
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         recorder = registry.get_recorder('db.duration')
         assert recorder is None
@@ -938,7 +940,7 @@ class TestGetRecorder:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         recorder = registry.get_recorder('unknown.metric')
         assert recorder is None

--- a/tests/common/test_observability_value_metrics.py
+++ b/tests/common/test_observability_value_metrics.py
@@ -30,7 +30,7 @@ class TestBuiltInValueMetrics:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         assert 'gen_ai.tokens.used' in registry._value_recorders
         assert 'gen_ai.cost.total' in registry._value_recorders
@@ -47,7 +47,7 @@ class TestBuiltInValueMetrics:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
         token_recorder = registry._value_recorders['gen_ai.tokens.used']
         assert 'owner.id' in token_recorder._excluded_labels
         cost_recorder = registry._value_recorders['gen_ai.cost.total']
@@ -56,7 +56,7 @@ class TestBuiltInValueMetrics:
     def test_value_metrics_disabled_when_observability_disabled(self):
         """Test value metrics not created when observability disabled."""
         config = {}
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
         assert registry.enabled is False
         assert registry._value_recorders == {}
 
@@ -78,7 +78,7 @@ class TestValueMetricsConfiguration:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
         token_recorder = registry._value_recorders['gen_ai.tokens.used']
         assert 'owner.id' not in token_recorder._excluded_labels
 
@@ -97,7 +97,7 @@ class TestValueMetricsConfiguration:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
         assert 'gen_ai.cost.total' not in registry._value_recorders
         assert 'gen_ai.tokens.used' in registry._value_recorders
 
@@ -116,7 +116,7 @@ class TestValueMetricsConfiguration:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
         assert 'gen_ai.tokens.used' in registry._value_recorders
         counter = registry.create_counter('my.custom.requests.total')
         assert isinstance(counter, CounterRecorder)
@@ -190,7 +190,7 @@ class TestValueMetricsRecording:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
         monitor = GenAITokenMonitor.create(
             model="gpt-4",
             component_name="TestAgent",
@@ -225,7 +225,7 @@ class TestValueMetricsRecording:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         monitor = GenAITokenMonitor.create(
             model="gpt-4",
@@ -259,7 +259,7 @@ class TestValueMetricsRecording:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
         monitor = GenAICostMonitor.create(
             model="gpt-4",
             component_name="TestAgent",
@@ -286,7 +286,7 @@ class TestValueMetricsRecording:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         monitor = GenAITokenMonitor.create(
             model="gpt-4",
@@ -374,7 +374,7 @@ class TestEndToEndValueMetrics:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
         token_recorder = registry._value_recorders['gen_ai.tokens.used']
         mock_token_counter = Mock()
         token_recorder._counter = mock_token_counter
@@ -416,7 +416,7 @@ class TestEndToEndValueMetrics:
                 }
             }
         }
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
         duration_recorder = registry.get_recorder('gen_ai.client.operation.duration')
         assert duration_recorder is not None
         token_recorder = registry.get_recorder('gen_ai.tokens.used')

--- a/tests/common/test_observability_without_initialization.py
+++ b/tests/common/test_observability_without_initialization.py
@@ -293,15 +293,16 @@ class TestObservabilityWithoutExplicitInitialization:
         assert instance1 is instance2
 
     def test_explicit_initialization_after_auto_init(self):
-        """Test explicit initialization works after auto-initialization."""
+        """Test explicit initialization overrides auto-initialization."""
         MetricRegistry.reset()
 
-        # Auto-initialize (disabled)
+        # Step 1: Instrumented code calls get_instance() early (auto-init)
         auto_instance = MetricRegistry.get_instance()
         assert auto_instance.enabled is False
+        assert auto_instance._explicitly_initialized is False
 
-        # Reset and explicitly initialize with enabled
-        MetricRegistry.reset()
+        # Step 2: Application startup calls initialize() with real config
+        # This should OVERRIDE the auto-initialized instance (not raise)
         config = {
             'management_server': {
                 'observability': {
@@ -311,5 +312,153 @@ class TestObservabilityWithoutExplicitInitialization:
         }
         explicit_instance = MetricRegistry.initialize(config)
 
+        # Should have created a NEW instance with enabled observability
         assert explicit_instance.enabled is True
+        assert explicit_instance._explicitly_initialized is True
         assert explicit_instance is not auto_instance
+
+        # Subsequent get_instance() calls should return the explicit instance
+        assert MetricRegistry.get_instance() is explicit_instance
+
+    def test_initialize_does_not_override_explicit_init(self):
+        """Test that initialize() raises when trying to override explicit initialization."""
+        MetricRegistry.reset()
+
+        # Explicitly initialize with config A
+        config_a = {
+            'management_server': {
+                'observability': {
+                    'enabled': True,
+                    'metric_prefix': 'app_a'
+                }
+            }
+        }
+        instance_a = MetricRegistry.initialize(config_a)
+        assert instance_a._explicitly_initialized is True
+
+        # Try to initialize with different config B - should raise
+        config_b = {
+            'management_server': {
+                'observability': {
+                    'enabled': True,
+                    'metric_prefix': 'app_b'  # Different!
+                }
+            }
+        }
+
+        with pytest.raises(RuntimeError, match="already initialized with different config"):
+            MetricRegistry.initialize(config_b)
+
+    def test_thread_safety_get_instance(self):
+        """Test get_instance() is thread-safe - no duplicate instances."""
+        import threading
+
+        MetricRegistry.reset()
+
+        instances = []
+        errors = []
+
+        def get_instance_in_thread():
+            try:
+                instance = MetricRegistry.get_instance()
+                instances.append(instance)
+            except Exception as e:
+                errors.append(e)
+
+        # Launch 10 threads simultaneously
+        threads = [threading.Thread(target=get_instance_in_thread) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # No errors should occur
+        assert len(errors) == 0
+
+        # All threads should get the SAME instance
+        assert len(instances) == 10
+        first_instance = instances[0]
+        assert all(inst is first_instance for inst in instances)
+
+    def test_thread_safety_initialize(self):
+        """Test initialize() is thread-safe - no duplicate instances."""
+        import threading
+
+        MetricRegistry.reset()
+
+        config = {
+            'management_server': {
+                'observability': {
+                    'enabled': True
+                }
+            }
+        }
+
+        instances = []
+        errors = []
+
+        def initialize_in_thread():
+            try:
+                instance = MetricRegistry.initialize(config)
+                instances.append(instance)
+            except Exception as e:
+                errors.append(e)
+
+        # Launch 10 threads simultaneously
+        threads = [threading.Thread(target=initialize_in_thread) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # No errors should occur
+        assert len(errors) == 0
+
+        # All threads should get the SAME instance
+        assert len(instances) == 10
+        first_instance = instances[0]
+        assert all(inst is first_instance for inst in instances)
+
+    def test_thread_safety_mixed_get_and_initialize(self):
+        """Test mixed get_instance() and initialize() calls are thread-safe."""
+        import threading
+        import random
+
+        MetricRegistry.reset()
+
+        config = {
+            'management_server': {
+                'observability': {
+                    'enabled': True
+                }
+            }
+        }
+
+        instances = []
+        errors = []
+
+        def random_access():
+            try:
+                # Randomly call get_instance() or initialize()
+                if random.choice([True, False]):
+                    instance = MetricRegistry.get_instance()
+                else:
+                    instance = MetricRegistry.initialize(config)
+                instances.append(instance)
+            except Exception as e:
+                errors.append(e)
+
+        # Launch 20 threads with mixed calls
+        threads = [threading.Thread(target=random_access) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # No errors should occur
+        assert len(errors) == 0
+
+        # All should eventually get same explicitly initialized instance
+        final_instance = MetricRegistry.get_instance()
+        assert final_instance._explicitly_initialized is True
+        assert final_instance.enabled is True

--- a/tests/common/test_observability_without_initialization.py
+++ b/tests/common/test_observability_without_initialization.py
@@ -1,0 +1,315 @@
+"""Test all observability APIs work safely when MetricRegistry is not explicitly initialized.
+
+This validates the defensive auto-initialization behavior - instrumented code should
+never fail even when observability is not explicitly set up.
+"""
+
+import pytest
+
+from solace_ai_connector.common.observability.registry import MetricRegistry
+from solace_ai_connector.common.observability import (
+    MonitorLatency,
+    BrokerMonitor,
+    GenAIMonitor,
+    GenAITTFTMonitor,
+    GenAITokenMonitor,
+    GenAICostMonitor,
+    DBMonitor,
+    OperationMonitor,
+)
+
+
+class TestObservabilityWithoutExplicitInitialization:
+    """Test all observability APIs when MetricRegistry NOT explicitly initialized."""
+
+    def test_get_instance_auto_initializes(self):
+
+        MetricRegistry.reset()
+
+        registry = MetricRegistry.get_instance()
+
+        assert registry is not None
+        assert registry.enabled is False
+        assert registry.duration_recorders == {}
+        assert registry._value_recorders == {}
+
+    def test_broker_monitor_without_initialization(self):
+        """Test BrokerMonitor works when registry not initialized."""
+        MetricRegistry.reset()
+
+        # Should not raise - becomes no-op
+        with MonitorLatency(BrokerMonitor.publish()):
+            pass
+
+    def test_genai_monitor_without_initialization(self):
+        """Test GenAIMonitor works when registry not initialized."""
+        MetricRegistry.reset()
+
+        monitor = GenAIMonitor.create(model="gpt-4")
+
+        with MonitorLatency(monitor):
+            pass
+
+    def test_genai_ttft_monitor_without_initialization(self):
+        """Test GenAITTFTMonitor works when registry not initialized."""
+        MetricRegistry.reset()
+
+        monitor = GenAITTFTMonitor.create(model="gpt-4")
+
+        with MonitorLatency(monitor):
+            pass
+
+    def test_genai_token_monitor_without_initialization(self):
+        """Test GenAITokenMonitor works when registry not initialized."""
+        MetricRegistry.reset()
+
+        monitor = GenAITokenMonitor.create(
+            model="gpt-4",
+            component_name="test-agent",
+            owner_id="test-user",
+            token_type="input"
+        )
+
+        assert monitor is not None
+        assert monitor.monitor_type == "gen_ai.tokens.used"
+
+    def test_genai_cost_monitor_without_initialization(self):
+        """Test GenAICostMonitor works when registry not initialized."""
+        MetricRegistry.reset()
+
+        monitor = GenAICostMonitor.create(
+            model="gpt-4",
+            component_name="test-agent",
+            owner_id="test-user"
+        )
+
+        assert monitor is not None
+        assert monitor.monitor_type == "gen_ai.cost.total"
+
+    def test_db_monitor_without_initialization(self):
+        """Test DBMonitor works when registry not initialized."""
+        MetricRegistry.reset()
+
+        monitor = DBMonitor.query("users")
+
+        with MonitorLatency(monitor):
+            pass
+
+    def test_operation_monitor_without_initialization(self):
+        """Test OperationMonitor works when registry not initialized."""
+        MetricRegistry.reset()
+
+        monitor = OperationMonitor.create(
+            component_type="processor",
+            component_name="transformer-1",
+            operation="transform"
+        )
+
+        with MonitorLatency(monitor):
+            pass
+
+    def test_monitor_latency_with_exception_no_initialization(self):
+        """Test MonitorLatency handles exceptions when registry not initialized."""
+        MetricRegistry.reset()
+
+        # Should not raise RuntimeError - exception should propagate normally
+        with pytest.raises(ValueError):
+            with MonitorLatency(BrokerMonitor.publish()):
+                raise ValueError("Test error")
+
+    def test_monitor_latency_async_without_initialization(self):
+        """Test async MonitorLatency works when registry not initialized."""
+        import asyncio
+
+        MetricRegistry.reset()
+
+        async def async_operation():
+            async with MonitorLatency(BrokerMonitor.publish()):
+                await asyncio.sleep(0.001)
+                return "result"
+
+        result = asyncio.run(async_operation())
+        assert result == "result"
+
+    def test_monitor_latency_decorator_sync_without_initialization(self):
+        """Test MonitorLatency as decorator on sync function when registry not initialized."""
+        MetricRegistry.reset()
+
+        @MonitorLatency(BrokerMonitor.publish())
+        def sync_function():
+            return "result"
+
+        result = sync_function()
+        assert result == "result"
+
+    def test_monitor_latency_decorator_async_without_initialization(self):
+        """Test MonitorLatency as decorator on async function when registry not initialized."""
+        import asyncio
+
+        MetricRegistry.reset()
+
+        @MonitorLatency(BrokerMonitor.publish())
+        async def async_function():
+            return "result"
+
+        result = asyncio.run(async_function())
+        assert result == "result"
+
+    def test_monitor_latency_manual_start_stop_without_initialization(self):
+        """Test manual start/stop when registry not initialized."""
+        MetricRegistry.reset()
+
+        monitor = MonitorLatency(BrokerMonitor.publish())
+        monitor.start()
+        monitor.stop()
+
+    def test_monitor_latency_manual_error_without_initialization(self):
+        """Test manual error recording when registry not initialized."""
+        MetricRegistry.reset()
+
+        monitor = MonitorLatency(BrokerMonitor.publish())
+        monitor.start()
+
+        try:
+            raise ValueError("Test error")
+        except ValueError as e:
+            monitor.error(e)
+
+    def test_all_monitors_in_sequence_without_initialization(self):
+        """Test using multiple monitors sequentially when registry not initialized."""
+        MetricRegistry.reset()
+
+        # All of these should work without raising
+        with MonitorLatency(BrokerMonitor.publish()):
+            pass
+
+        with MonitorLatency(GenAIMonitor.create("gpt-4")):
+            pass
+
+        with MonitorLatency(DBMonitor.query("users")):
+            pass
+
+        with MonitorLatency(OperationMonitor.create("processor", "comp-1", "process")):
+            pass
+
+    def test_nested_monitors_without_initialization(self):
+        """Test nested MonitorLatency contexts when registry not initialized."""
+        MetricRegistry.reset()
+
+        with MonitorLatency(OperationMonitor.create("processor", "comp-1", "outer")):
+            with MonitorLatency(DBMonitor.query("users")):
+                with MonitorLatency(GenAIMonitor.create("gpt-4")):
+                    pass
+
+    def test_registry_create_counter_without_initialization(self):
+        """Test registry.create_counter() works when not initialized."""
+        MetricRegistry.reset()
+
+        registry = MetricRegistry.get_instance()
+        counter = registry.create_counter("test.counter", "Test counter")
+
+        # Should return NoOpRecorder since auto-initialized disabled
+        from solace_ai_connector.common.observability.recorders import NoOpRecorder
+        assert isinstance(counter, NoOpRecorder)
+
+        # Should not raise
+        counter.record(1, {"label": "value"})
+
+    def test_registry_create_gauge_without_initialization(self):
+        """Test registry.create_gauge() works when not initialized."""
+        MetricRegistry.reset()
+
+        registry = MetricRegistry.get_instance()
+        gauge = registry.create_gauge("test.gauge", "Test gauge")
+
+        # Should return NoOpRecorder since auto-initialized disabled
+        from solace_ai_connector.common.observability.recorders import NoOpRecorder
+        assert isinstance(gauge, NoOpRecorder)
+
+        # Should not raise
+        gauge.record(42, {"label": "value"})
+
+    def test_registry_create_observable_gauge_without_initialization(self):
+        """Test registry.create_observable_gauge() works when not initialized."""
+        MetricRegistry.reset()
+
+        registry = MetricRegistry.get_instance()
+
+        def callback(options):
+            from opentelemetry.metrics import Observation
+            return [Observation(10, {"queue": "main"})]
+
+        # Should return NoOpObservableGauge (not None) for consistency
+        result = registry.create_observable_gauge(
+            "test.observable",
+            [callback],
+            "Test observable gauge"
+        )
+
+        from solace_ai_connector.common.observability.recorders import NoOpObservableGauge
+        assert isinstance(result, NoOpObservableGauge)
+
+    def test_registry_get_recorder_without_initialization(self):
+        """Test registry.get_recorder() works when not initialized."""
+        MetricRegistry.reset()
+
+        registry = MetricRegistry.get_instance()
+        recorder = registry.get_recorder("gen_ai.client.operation.duration")
+
+        # Should return None since auto-initialized disabled
+        assert recorder is None
+
+    def test_all_monitor_factory_methods_without_initialization(self):
+        """Test all monitor factory methods work when registry not initialized."""
+        MetricRegistry.reset()
+
+        # All factory methods should succeed
+        monitors = [
+            BrokerMonitor.publish(),
+            GenAIMonitor.create("gpt-4"),
+            GenAITTFTMonitor.create("gpt-4"),
+            GenAITokenMonitor.create("gpt-4", "agent", "user", "input"),
+            GenAICostMonitor.create("gpt-4", "agent", "user"),
+            DBMonitor.query("users"),
+            DBMonitor.insert("users"),
+            DBMonitor.update("users"),
+            DBMonitor.delete("users"),
+            OperationMonitor.create("processor", "comp-1", "transform"),
+        ]
+
+        # All should be MonitorInstance objects
+        for monitor in monitors:
+            assert monitor is not None
+            assert hasattr(monitor, 'monitor_type')
+            assert hasattr(monitor, 'labels')
+
+    def test_get_instance_singleton_behavior(self):
+        """Test get_instance() returns same instance across calls."""
+        MetricRegistry.reset()
+
+        instance1 = MetricRegistry.get_instance()
+        instance2 = MetricRegistry.get_instance()
+
+        assert instance1 is instance2
+
+    def test_explicit_initialization_after_auto_init(self):
+        """Test explicit initialization works after auto-initialization."""
+        MetricRegistry.reset()
+
+        # Auto-initialize (disabled)
+        auto_instance = MetricRegistry.get_instance()
+        assert auto_instance.enabled is False
+
+        # Reset and explicitly initialize with enabled
+        MetricRegistry.reset()
+        config = {
+            'management_server': {
+                'observability': {
+                    'enabled': True
+                }
+            }
+        }
+        explicit_instance = MetricRegistry.initialize(config)
+
+        assert explicit_instance.enabled is True
+        assert explicit_instance is not auto_instance

--- a/tests/components/general/llm/litellm/conftest.py
+++ b/tests/components/general/llm/litellm/conftest.py
@@ -22,7 +22,7 @@ def initialize_metric_registry():
     """Initialize MetricRegistry before each test and reset after."""
     # Initialize with observability disabled for tests (avoid side effects)
     config = {}
-    MetricRegistry(config)
+    MetricRegistry.initialize(config)
 
     yield
 

--- a/tests/components/general/llm/litellm/test_litellm_observability.py
+++ b/tests/components/general/llm/litellm/test_litellm_observability.py
@@ -33,7 +33,7 @@ class TestLiteLLMNonStreamingObservability:
             }
         }
         MetricRegistry.reset()  # Clear any previous instance
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         with patch(
             "solace_ai_connector.components.general.llm.litellm.litellm_base.litellm.Router"
@@ -127,7 +127,7 @@ class TestLiteLLMNonStreamingObservability:
             }
         }
         MetricRegistry.reset()
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         with patch(
             "solace_ai_connector.components.general.llm.litellm.litellm_base.litellm.Router"
@@ -178,7 +178,7 @@ class TestLiteLLMNonStreamingObservability:
             }
         }
         MetricRegistry.reset()
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         with patch(
             "solace_ai_connector.components.general.llm.litellm.litellm_base.litellm.Router"
@@ -234,7 +234,7 @@ class TestLiteLLMStreamingObservability:
             }
         }
         MetricRegistry.reset()
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         with patch(
             "solace_ai_connector.components.general.llm.litellm.litellm_base.litellm.Router"
@@ -330,7 +330,7 @@ class TestLiteLLMHistogramRecording:
             }
         }
         MetricRegistry.reset()
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         with patch(
             "solace_ai_connector.components.general.llm.litellm.litellm_base.litellm.Router"
@@ -395,7 +395,7 @@ class TestLiteLLMHistogramRecording:
             }
         }
         MetricRegistry.reset()
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         with patch(
             "solace_ai_connector.components.general.llm.litellm.litellm_base.litellm.Router"
@@ -463,7 +463,7 @@ class TestLiteLLMTokenBucketization:
             }
         }
         MetricRegistry.reset()
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         with patch(
             "solace_ai_connector.components.general.llm.litellm.litellm_base.litellm.Router"
@@ -524,7 +524,7 @@ class TestLiteLLMTTFTRecording:
             }
         }
         MetricRegistry.reset()
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         with patch(
             "solace_ai_connector.components.general.llm.litellm.litellm_base.litellm.Router"
@@ -606,7 +606,7 @@ class TestLiteLLMTTFTRecording:
             }
         }
         MetricRegistry.reset()
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         with patch(
             "solace_ai_connector.components.general.llm.litellm.litellm_base.litellm.Router"
@@ -670,7 +670,7 @@ class TestLiteLLMTTFTRecording:
             }
         }
         MetricRegistry.reset()
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         with patch(
             "solace_ai_connector.components.general.llm.litellm.litellm_base.litellm.Router"
@@ -727,7 +727,7 @@ class TestLiteLLMLabelFiltering:
             }
         }
         MetricRegistry.reset()
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         with patch(
             "solace_ai_connector.components.general.llm.litellm.litellm_base.litellm.Router"
@@ -778,7 +778,7 @@ class TestLiteLLMLabelFiltering:
         """Test that no metrics are recorded when observability is disabled."""
         config = {}  # No observability config = disabled
         MetricRegistry.reset()
-        registry = MetricRegistry(config)
+        registry = MetricRegistry.initialize(config)
 
         with patch(
             "solace_ai_connector.components.general.llm.litellm.litellm_base.litellm.Router"


### PR DESCRIPTION
🧩 Complexity Level: 🟢 Low

 <!-- Example: 5-10 minutes -->
⏱️ Estimated Review Time: 10–15 minutes

### What is the purpose of this change?
 - Make observability framework defensive and fail-safe - this will allow underlying repos (SAM/SAMe) - to instrument codebase without checking whether stack is on/off


### How is this accomplished?
  - Added `MetricRegistry.initialize(config)` factory method
  - Updated `get_instance()` to auto-initialize defensively
  - Added `NoOpObservableGauge` class for consistency
  - Updated connector to use `initialize()` instead of constructor
  - Added comprehensive test  validating all APIs work without explicit initialization
  

### Anything reviews should focus on/be aware of?
