### PR TITLE
ci(DATAGO-131317): add packages:read permission for GHCR container pull

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,6 +34,7 @@ permissions:
   pull-requests: write
   actions: read
   statuses: write
+  packages: read
 
 jobs:
   # Gate: only admins can bypass security checks


### PR DESCRIPTION
## Summary

- Adds `packages: read` to the workflow-level `permissions` block

## Why

CI container maas-build-actions from solacelabs needs package read permissions

## Impact

Without this change, security check steps that pull `ghcr.io/solacelabs/maas-build-actions` will fail with `unauthorized` once the updated SPW composite actions land on `main`.

## Test plan
- [ ] Trigger a release workflow after merging and confirm `docker login ghcr.io` succeeds
- [ ] Confirm `maas-build-actions` container pulls without `unauthorized` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)