### PR TITLE
ci(DATAGO-131317): fix: add packages: read for GHCR image pull

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,7 @@ permissions:
   issues: write
   checks: write
   statuses: write
+  packages: read
 
 jobs:
   # FOSSA security scanning - runs in parallel with CI (skipped for forks, no secret access)

--- a/.github/workflows/fossa-scan.yaml
+++ b/.github/workflows/fossa-scan.yaml
@@ -20,6 +20,7 @@ permissions:
   issues: write
   checks: write
   statuses: write
+  packages: read
 
 jobs:
   fossa_scan:


### PR DESCRIPTION
## Summary

Adds `packages: read` permission to `.github/workflows/ci.yaml` and `.github/workflows/fossa-scan.yaml`.

## Context

An upcoming change in `solace-public-workflows` updates the composite actions (`fossa-guard`, `cicd-helper`, `generate-fossa-report`) to pull the `maas-build-actions` container image from GHCR using explicit `docker login` + `docker run`. Pulling from GHCR requires the calling workflow's token to have at least `packages: read` — without it, `docker login` returns a 403 and the job fails.