### PR TITLE
feat(DATAGO-128307): observability|SAMe introduce OTEL exporter

### DIFF
--- a/src/solace_ai_connector/common/observability/registry.py
+++ b/src/solace_ai_connector/common/observability/registry.py
@@ -24,6 +24,9 @@ class MetricRegistry:
     _instance: Optional['MetricRegistry'] = None
     _lock = threading.Lock()
 
+    # Enterprise hook: Additional metric exporters registered before initialization
+    _additional_exporters: List = []
+
     def __init__(self, config: dict):
         """
         Use MetricRegistry.initialize(config) for explicit initialization.
@@ -131,10 +134,27 @@ class MetricRegistry:
         return cls._instance
 
     @classmethod
+    def register_additional_exporter(cls, exporter):
+        """
+        Register additional metric exporter before MetricRegistry initialization.
+
+        This is a hook to add custom exporters (OTLP, Datadog, etc.)
+        before the MeterProvider is created.
+
+        MUST be called BEFORE MetricRegistry.initialize().
+
+        Args:
+            exporter: MetricExporter instance (e.g., OTLPMetricExporter, DatadogExporter)
+        """
+        cls._additional_exporters.append(exporter)
+        logger.debug("Registered additional metric exporter: %s", exporter.__class__.__name__)
+
+    @classmethod
     def reset(cls):
         """Reset singleton (for testing)."""
         with cls._lock:
             cls._instance = None
+            cls._additional_exporters = []  # Also reset additional exporters
 
     def _prepare_metric_configs(self) -> Dict:
         """Merge user config with defaults for distribution metrics (histograms)."""
@@ -239,8 +259,24 @@ class MetricRegistry:
 
         # Step 2: Create MeterProvider with Prometheus exporter and Views
         self.prometheus_exporter = PrometheusMetricReader()
+
+        # Collect all metric readers (Prometheus + any additional)
+        metric_readers = [self.prometheus_exporter]
+
+        # Add enterprise/plugin exporters registered via register_additional_exporter()
+        if self._additional_exporters:
+            logger.info("Adding %d additional metric exporter(s) from enterprise", len(self._additional_exporters))
+            for exporter in self._additional_exporters:
+                reader = PeriodicExportingMetricReader(
+                    exporter=exporter,
+                    export_interval_millis=60000  # 60 seconds
+                )
+                metric_readers.append(reader)
+                logger.info("Wrapped additional exporter in PeriodicExportingMetricReader: %s", exporter.__class__.__name__)
+
+        # Create MeterProvider with ALL readers (Prometheus + additional)
         self.meter_provider = MeterProvider(
-            metric_readers=[self.prometheus_exporter],
+            metric_readers=metric_readers,
             views=views
         )
         metrics.set_meter_provider(self.meter_provider)
@@ -465,27 +501,3 @@ class MetricRegistry:
         # Generate Prometheus format output from the registry
         return generate_latest(REGISTRY)
 
-    def add_exporter(self, exporter):
-        """
-        Add additional metric exporter (OTLP, Datadog, etc.).
-
-        Called by downstream code (solace-agent-mesh-enterprise).
-
-        Args:
-            exporter: OpenTelemetry metric exporter instance
-        """
-        if not self.enabled:
-            logger.warning("Cannot add exporter - observability is disabled")
-            return
-
-        # Wrap exporter in periodic reader
-        reader = PeriodicExportingMetricReader(
-            exporter=exporter,
-            export_interval_millis=60000  # 60 seconds
-        )
-
-        # Add to meter provider
-        self.meter_provider._sdk_config.metric_readers.append(reader)
-        reader._set_meter_provider(self.meter_provider)
-
-        logger.info("Added metric exporter: %s", exporter.__class__.__name__)

--- a/tests/common/test_observability.py
+++ b/tests/common/test_observability.py
@@ -944,3 +944,71 @@ class TestGetRecorder:
 
         recorder = registry.get_recorder('unknown.metric')
         assert recorder is None
+
+
+class TestAdditionalExporters:
+    """Test register_additional_exporter and enterprise exporter integration."""
+
+    def test_register_additional_exporter_adds_to_list(self):
+        """Test that register_additional_exporter appends exporter to class list."""
+        MetricRegistry.reset()
+
+        mock_exporter = Mock()
+        mock_exporter.__class__.__name__ = 'OTLPMetricExporter'
+
+        MetricRegistry.register_additional_exporter(mock_exporter)
+
+        assert mock_exporter in MetricRegistry._additional_exporters
+        assert len(MetricRegistry._additional_exporters) == 1
+
+        MetricRegistry.reset()
+
+    def test_additional_exporters_wrapped_during_initialization(self):
+        """Test that registered exporters are wrapped in PeriodicExportingMetricReader."""
+        MetricRegistry.reset()
+
+        # Create a properly mocked exporter that satisfies OTel's requirements
+        mock_exporter = Mock()
+        mock_exporter.__class__.__name__ = 'OTLPMetricExporter'
+
+        MetricRegistry.register_additional_exporter(mock_exporter)
+
+        config = {
+            'management_server': {
+                'observability': {
+                    'enabled': True,
+                    'path': '/metrics'
+                }
+            }
+        }
+
+        # Mock PeriodicExportingMetricReader to avoid actual OTel initialization issues
+        with patch('solace_ai_connector.common.observability.registry.PeriodicExportingMetricReader') as mock_reader_class:
+            # Create distinct mock instances for each call
+            mock_reader_instance = Mock()
+            mock_reader_class.return_value = mock_reader_instance
+
+            registry = MetricRegistry.initialize(config)
+
+            # Verify PeriodicExportingMetricReader was called with the registered exporter
+            mock_reader_class.assert_called_once_with(
+                exporter=mock_exporter,
+                export_interval_millis=60000
+            )
+
+            assert registry.enabled is True
+
+        MetricRegistry.reset()
+
+    def test_reset_clears_additional_exporters(self):
+        """Test that reset() clears the additional exporters list."""
+        MetricRegistry.reset()
+
+        mock_exporter = Mock()
+        MetricRegistry.register_additional_exporter(mock_exporter)
+
+        assert len(MetricRegistry._additional_exporters) == 1
+
+        MetricRegistry.reset()
+
+        assert len(MetricRegistry._additional_exporters) == 0


### PR DESCRIPTION
🧩 Complexity Level: 🟢 Low

 <!-- Example: 5-10 minutes -->
⏱️ Estimated Review Time: 10–15 minutes

### What is the purpose of this change?
- in order to enable OTEL exporters (in enteprise use case) we ned to update conenctor to accept exporters before init time, since exporters must be known to MetricProvider before the last one is initialised.

### How is this accomplished?
- new class level variable to store custom exporters

### Anything reviews should focus on/be aware of?