### PR TITLE
fix(DATAGO-136673): bump urllib3 2.6.3 -> 2.7.0 for CVE-2026-44431/44432

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "gevent==25.8.2",
     "gevent-websocket==0.10.1",
     "python-json-logger==4.0.0",
-    "urllib3==2.6.3",
+    "urllib3==2.7.0",
     "opentelemetry-api>=1.37.0,<2.0.0",
     "opentelemetry-sdk>=1.37.0,<2.0.0",
     "opentelemetry-exporter-prometheus>=0.58b0,<1.0.0"


### PR DESCRIPTION
## Summary
- Bumps `urllib3` pin from `2.6.3` to `2.7.0` to fix two BLOCKING FOSSA vulnerabilities flagged on the SAM vuln dashboard:
  - **CVE-2026-44431** (HIGH)
  - **CVE-2026-44432** (HIGH)
- Strict `urllib3==2.6.3` pin currently caps the version downstream in `solace-agent-mesh` (and enterprise), preventing the fix from being picked up via `uv lock`. Bumping here unblocks the downstream fix.

## Test plan
- [ ] CI passes
- [ ] Downstream `solace-agent-mesh` `uv lock` resolves `urllib3` to `2.7.0` after this is merged and version bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)