### PR TITLE
ci: remove SonarQube references

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,8 +44,6 @@ jobs:
       min-python-version: "3.10"
       max-python-version: "3.13"
     secrets:
-      SONAR_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}
-      SONAR_HOST_URL: ${{ secrets.SONARQUBE_HOST_URL }}
       MANIFEST_AWS_ACCESS_KEY_ID: ${{ secrets.MANIFEST_READ_ONLY_AWS_ACCESS_KEY_ID }}
       MANIFEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.MANIFEST_READ_ONLY_AWS_SECRET_ACCESS_KEY }}
       MANIFEST_AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,7 +72,7 @@ jobs:
     secrets:
       FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
 
-  # Other security checks (SonarQube, WhiteSource) - runs after permission check, in parallel with FOSSA
+  # Other security checks (WhiteSource) - runs after permission check, in parallel with FOSSA
   other_security_checks:
     name: Security Checks
     needs: [check_skip_permission]
@@ -82,13 +82,9 @@ jobs:
       !fromJSON(github.event.inputs.skip_security_checks)
     uses: SolaceDev/solace-public-workflows/.github/workflows/hatch_release_security_checks.yml@main
     with:
-      sonarqube_hotspot_check: true
+      sonarqube_hotspot_check: false
       fossa_check: false
     secrets:
-      SONARQUBE_PROJECT_KEY: ${{ github.event.repository.owner }}_${{ github.event.repository.name }}
-      SONARQUBE_PROJECT_MAIN_BRANCH: "main"
-      SONARQUBE_QUERY_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}
-      SONARQUBE_HOTSPOTS_API_URL: ${{ secrets.SONARQUBE_HOTSPOTS_API_URL }}
       MANIFEST_AWS_ACCESS_KEY_ID: ${{ secrets.MANIFEST_READ_ONLY_AWS_ACCESS_KEY_ID }}
       MANIFEST_AWS_SECRET_ACCESS_KEY: ${{ secrets.MANIFEST_READ_ONLY_AWS_SECRET_ACCESS_KEY }}
       MANIFEST_AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}


### PR DESCRIPTION
## Why
SonarQube projects for these repos are being decommissioned. This removes every SonarQube reference from CI so the project can be safely deleted.

## Changes
- **`ci.yaml`**: dropped `SONAR_TOKEN`/`SONAR_HOST_URL` secrets from the `hatch_ci.yml` call.
- **`release.yaml`**: set `sonarqube_hotspot_check: false` on the `hatch_release_security_checks.yml` call and removed the `SONARQUBE_*` secrets (job retained so other default security behavior is unaffected).

**Note:** unlike the other SAM repos, tests here run inside an external reusable workflow (`solace-public-workflows/.github/workflows/hatch_ci.yml`), so no in-repo `CodeCoverageSummary` step is added — this is SonarQube removal only.

## Follow-ups (outside this PR)
- Delete the SonarQube project after merge.
- Apply the same removal to `test_security_scan.yaml` if/when that WIP branch merges (that file is not on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)